### PR TITLE
fix: แก้ไข style ตามที่ Ruff แจ้งใน CI

### DIFF
--- a/scripts/validate_result.py
+++ b/scripts/validate_result.py
@@ -102,7 +102,7 @@ def validate_result(file_path: str = "output/preflight_result.json") -> bool:
                 return False
 
             score = scores_obj[field]
-            if not isinstance(score, (int, float)):
+            if not isinstance(score, int | float):
                 print(f"❌ หัวข้อ #{i + 1} {field} ต้องเป็นตัวเลข")
                 return False
 

--- a/src/agents/trend_scout/agent.py
+++ b/src/agents/trend_scout/agent.py
@@ -22,7 +22,6 @@ from automation_core.utils.text import (
 )
 
 from .model import (
-    DiscardedDuplicate,
     MetaInfo,
     SelfCheck,
     TopicEntry,
@@ -64,7 +63,7 @@ class TrendScoutAgent(BaseAgent[TrendScoutInput, TrendScoutOutput]):
         self.content_pillars = [
             "ธรรมะประยุกต์",
             "ชาดก/นิทานสอนใจ",
-            "ธรรมะสั้น", 
+            "ธรรมะสั้น",
             "เจาะลึก/ซีรีส์",
             "Q&A/ตอบคำถาม",
             "สรุปพระสูตร/หนังสือ",

--- a/src/agents/trend_scout/model.py
+++ b/src/agents/trend_scout/model.py
@@ -165,7 +165,7 @@ class MetaInfo(BaseModel):
 
 class DiscardedDuplicate(BaseModel):
     """หัวข้อที่ถูกตัดออกเพราะซ้ำ"""
-    
+
     title: str = Field(description="ชื่อหัวข้อที่ถูกตัด")
     reason: str = Field(description="เหตุผลที่ถูกตัด")
 

--- a/src/automation_core/utils/scoring.py
+++ b/src/automation_core/utils/scoring.py
@@ -121,7 +121,7 @@ def validate_score_range(
     """
 
     for score in scores.values():
-        if not isinstance(score, (int, float)):
+        if not isinstance(score, int | float):
             return False
         if score < min_val or score > max_val:
             return False


### PR DESCRIPTION
## Summary
- ปรับเช็คคะแนนใน `validate_result.py` และ `scoring.py` ให้ใช้ union type ตามข้อเสนอของ Ruff
- ล้าง import ที่ไม่ถูกใช้งานและจัดรูปแบบเล็กน้อยใน `trend_scout/agent.py`
- เก็บกวาดช่องว่างส่วนเกินใน `trend_scout/model.py`

## Testing
- `ruff check . --fix`
- `ruff format .`


------
https://chatgpt.com/codex/tasks/task_e_68d0cc4ea0588320a46600053e6703e6