### PR TITLE
Improve warning assertions in agent tests

### DIFF
--- a/scripts/test_script_writer.py
+++ b/scripts/test_script_writer.py
@@ -31,7 +31,7 @@ from agents.script_writer import (
 def create_test_outline():
     """สร้าง sample outline สำหรับทดสอบ"""
     outline_agent = ScriptOutlineAgent()
-    
+
     input_data = ScriptOutlineInput(
         topic_title="ปล่อยวางความกังวลก่อนนอน",
         summary_bullets=[
@@ -45,18 +45,16 @@ def create_test_outline():
         viewer_persona=ViewerPersona(
             name="คนทำงานเมือง",
             pain_points=["เครียดจากการทำงาน", "นอนไม่หลับ", "วิตกกังวล"],
-            desired_state="ใจสงบ นอนหลับสนิท มีความสุข"
+            desired_state="ใจสงบ นอนหลับสนิท มีความสุข",
         ),
         style_preferences=StylePreferences(
-            tone="อบอุ่น สงบ ไม่สั่งสอน", 
-            avoid=["ศัพท์บาลีหนักเกินไป", "การตำหนิตัวผู้ชม"]
+            tone="อบอุ่น สงบ ไม่สั่งสอน", avoid=["ศัพท์บาลีหนักเกินไป", "การตำหนิตัวผู้ชม"]
         ),
         retention_goals=RetentionGoals(
-            hook_drop_max_pct=30, 
-            mid_segment_break_every_sec=120
+            hook_drop_max_pct=30, mid_segment_break_every_sec=120
         ),
     )
-    
+
     return outline_agent.run(input_data)
 
 
@@ -73,10 +71,10 @@ def create_test_passages():
             relevance_final=0.95,
             doctrinal_tags=["สติ", "สติปฏฐาน", "สมาธิ"],
             license="public_domain",
-            reason="หลักการฝึกสติที่เกี่ยวข้องตรงกับเรื่องความกังวล"
+            reason="หลักการฝึกสติที่เกี่ยวข้องตรงกับเรื่องความกังวล",
         ),
         Passage(
-            id="p210", 
+            id="p210",
             source_name="อานาปานสติสูตร",
             collection="พระสุตตันตปิฎก",
             canonical_ref="MN 118",
@@ -84,23 +82,23 @@ def create_test_passages():
             thai_modernized="การสติดูลมหายใจที่พัฒนาแล้วจะทำให้ใจสงบ ผู้ฝึกควรตั้งสติสังเกตลมหายใจเข้าออก",
             relevance_final=0.9,
             doctrinal_tags=["อานาปานสติ", "สมาธิ", "ความสงบ"],
-            license="public_domain", 
-            reason="วิธีการหายใจเพื่อความสงบก่อนนอน"
+            license="public_domain",
+            reason="วิธีการหายใจเพื่อความสงบก่อนนอน",
         ),
         Passage(
             id="p345",
             source_name="สัญญุตตนิกาย",
-            collection="พระสุตตันตปิฎก", 
+            collection="พระสุตตันตปิฎก",
             canonical_ref="SN 36.6",
             original_text="เวทนาสามประการ สุขเวทนา ทุกข์เวทนา อทุกขมสุขเวทนา ถ้ารู้แจ้งแล้วย่อมไม่ยึดติด",
             thai_modernized="ความรู้สึก 3 แบบ คือ รู้สึกสุข ทุกข์ และเป็นกลาง ถ้ารู้จักแล้วจะไม่ยึดติด",
             relevance_final=0.85,
             doctrinal_tags=["เวทนา", "ไตรลักษณ์", "ปล่อยวาง"],
             license="public_domain",
-            reason="การรู้จักเวทนาช่วยปล่อยวางความกังวล"
-        )
+            reason="การรู้จักเวทนาช่วยปล่อยวางความกังวล",
+        ),
     ]
-    
+
     supportive_passages = [
         Passage(
             id="p456",
@@ -112,29 +110,29 @@ def create_test_passages():
             relevance_final=0.7,
             doctrinal_tags=["เมตตา", "พรหมวิหาร", "ความรัก"],
             license="public_domain",
-            reason="เมตตาช่วยคลายความตึงเครียดก่อนนอน"
+            reason="เมตตาช่วยคลายความตึงเครียดก่อนนอน",
         )
     ]
-    
+
     return PassageData(primary=primary_passages, supportive=supportive_passages)
 
 
 def test_script_writer_agent():
     """ทดสอบ ScriptWriterAgent แบบ manual"""
-    
+
     print("🚀 เริ่มทดสอบ ScriptWriterAgent...")
-    
+
     # สร้าง agent
     agent = ScriptWriterAgent()
     print(f"✅ สร้าง {agent.name} v{agent.version} สำเร็จ")
-    
+
     # สร้าง outline และ passages
     print("📋 กำลังสร้าง outline...")
     outline = create_test_outline()
-    
+
     print("📚 กำลังสร้าง passages...")
     passages = create_test_passages()
-    
+
     # สร้าง input data
     input_data = ScriptWriterInput(
         outline=outline,
@@ -142,69 +140,72 @@ def test_script_writer_agent():
         style_notes=StyleNotes(
             tone="อบอุ่น สงบ ไม่สั่งสอน",
             voice="เป็นกันเอง สุภาพ ใช้คำว่า เรา/คุณ",
-            avoid=["ศัพท์บาลีติดกันหลายคำ", "การชี้นำผลลัพธ์แน่นอน"]
+            avoid=["ศัพท์บาลีติดกันหลายคำ", "การชี้นำผลลัพธ์แน่นอน"],
         ),
         target_seconds=600,
-        language="th"
+        language="th",
     )
-    
+
     print(f"📝 สร้าง input สำหรับหัวข้อ: {input_data.outline.topic}")
     print(f"   - Outline sections: {len(input_data.outline.outline)}")
     print(f"   - Primary passages: {len(input_data.passages.primary)}")
     print(f"   - Supportive passages: {len(input_data.passages.supportive)}")
     print(f"   - Target duration: {input_data.target_seconds} วินาที")
-    
+
     # ประมวลผลด้วย agent
     try:
         print("\n⚙️ กำลังเรียบเรียงสคริปต์...")
         result = agent.run(input_data)
         print("✅ Agent ประมวลผลสำเร็จ!")
-        
+
         # แสดงผลลัพธ์
-        print(f"\n📊 ผลลัพธ์:")
+        print("\n📊 ผลลัพธ์:")
         print(f"   - หัวข้อ: {result.topic}")
         print(f"   - จำนวน segments: {len(result.segments)}")
         print(f"   - ระยะเวลารวม: {result.duration_est_total} วินาที")
         print(f"   - Citations ที่ใช้: {len(result.citations_used)} รายการ")
         print(f"   - Unmatched citations: {len(result.unmatched_citations)} รายการ")
-        
-        print(f"\n📈 Meta information:")
+
+        print("\n📈 Meta information:")
         print(f"   - Reading speed: {result.meta.reading_speed_wpm} WPM")
         print(f"   - Retention cues: {result.meta.interrupts_count} ตัว")
         print(f"   - Teaching segments: {result.meta.teaching_segments} ชิ้น")
         print(f"   - Practice steps: {result.meta.practice_steps_count} ขั้นตอน")
-        
-        print(f"\n✅ Quality Check:")
+
+        print("\n✅ Quality Check:")
         qc = result.quality_check
         print(f"   - Citations valid: {qc.citations_valid}")
         print(f"   - Teaching has citation: {qc.teaching_has_citation}")
         print(f"   - Duration within range: {qc.duration_within_range}")
         print(f"   - Hook within 8s: {qc.hook_within_8s}")
         print(f"   - No prohibited claims: {qc.no_prohibited_claims}")
-        
+
         if result.warnings:
-            print(f"\n⚠️ Warnings:")
+            print("\n⚠️ Warnings:")
             for warning in result.warnings:
                 print(f"   - {warning}")
-        
-        print(f"\n📝 Script Segments:")
+
+        print("\n📝 Script Segments:")
         for i, segment in enumerate(result.segments):
-            print(f"\n{i+1}. {segment.segment_type.value.upper()} ({segment.est_seconds}s)")
+            print(
+                f"\n{i + 1}. {segment.segment_type.value.upper()} ({segment.est_seconds}s)"
+            )
             print(f"   {segment.text}")
-        
+
         print(f"\n🎯 Citations used: {', '.join(result.citations_used)}")
-        
+
         # บันทึกผลลัพธ์เป็น JSON
         output_path = Path("/tmp/script_writer_test_result.json")
         with open(output_path, "w", encoding="utf-8") as f:
             json.dump(result.model_dump(), f, ensure_ascii=False, indent=2)
         print(f"\n💾 บันทึกผลลัพธ์ไว้ที่: {output_path}")
-        
+
         return True
-        
+
     except Exception as e:
         print(f"❌ เกิดข้อผิดพลาด: {e}")
         import traceback
+
         traceback.print_exc()
         return False
 

--- a/src/agents/script_writer/agent.py
+++ b/src/agents/script_writer/agent.py
@@ -44,8 +44,15 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
 
         # คำที่ห้ามใช้เพราะเป็นการยืนยันผลแน่นอน
         self.prohibited_claims = [
-            "100%", "รับรอง", "การันตี", "แน่นอน", "ได้แน่",
-            "หลับได้แน่", "หายได้แน่", "จะได้", "ต้องได้"
+            "100%",
+            "รับรอง",
+            "การันตี",
+            "แน่นอน",
+            "ได้แน่",
+            "หลับได้แน่",
+            "หายได้แน่",
+            "จะได้",
+            "ต้องได้",
         ]
 
         # ค่าเฉลี่ยความเร็วอ่านภาษาไทย (คำต่อนาที)
@@ -128,11 +135,13 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
 
         except Exception as e:
             logger.error(f"เกิดข้อผิดพลาดในการเรียบเรียงสคริปต์: {e}")
-            return self._create_error_response({
-                "code": "SCHEMA_VIOLATION",
-                "message": f"เกิดข้อผิดพลาด: {str(e)}",
-                "suggested_fix": "ตรวจสอบข้อมูลนำเข้าและลองใหม่"
-            })
+            return self._create_error_response(
+                {
+                    "code": "SCHEMA_VIOLATION",
+                    "message": f"เกิดข้อผิดพลาด: {str(e)}",
+                    "suggested_fix": "ตรวจสอบข้อมูลนำเข้าและลองใหม่",
+                }
+            )
 
     def _validate_input_data(self, input_data: ScriptWriterInput) -> dict | None:
         """ตรวจสอบข้อมูลนำเข้า"""
@@ -140,15 +149,17 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
             return {
                 "code": "MISSING_DATA",
                 "message": "ไม่พบโครงร่างในข้อมูลนำเข้า",
-                "suggested_fix": "ตรวจสอบ outline ให้มี sections อย่างน้อย 1 รายการ"
+                "suggested_fix": "ตรวจสอบ outline ให้มี sections อย่างน้อย 1 รายการ",
             }
 
-        total_passages = len(input_data.passages.primary) + len(input_data.passages.supportive)
+        total_passages = len(input_data.passages.primary) + len(
+            input_data.passages.supportive
+        )
         if total_passages == 0:
             return {
                 "code": "MISSING_DATA",
                 "message": "ไม่พบข้อความอ้างอิง passages",
-                "suggested_fix": "ตรวจสอบ passages ให้มี primary หรือ supportive อย่างน้อย 1 รายการ"
+                "suggested_fix": "ตรวจสอบ passages ให้มี primary หรือ supportive อย่างน้อย 1 รายการ",
             }
 
         return None
@@ -159,7 +170,7 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
         error_segment = ScriptSegment(
             segment_type=SegmentType.HOOK,
             text="เกิดข้อผิดพลาดในการเรียบเรียงสคริปต์",
-            est_seconds=5
+            est_seconds=5,
         )
 
         return ScriptWriterOutput(
@@ -172,16 +183,18 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
                 reading_speed_wpm=145,
                 interrupts_count=0,
                 teaching_segments=0,
-                practice_steps_count=0
+                practice_steps_count=0,
             ),
             quality_check=QualityCheck(
                 citations_valid=False,
                 teaching_has_citation=False,
                 duration_within_range=False,
                 hook_within_8s=False,
-                no_prohibited_claims=True
+                no_prohibited_claims=True,
             ),
-            warnings=[f"ERROR: {error_dict['message']} - {error_dict['suggested_fix']}"]
+            warnings=[
+                f"ERROR: {error_dict['message']} - {error_dict['suggested_fix']}"
+            ],
         )
 
     def _build_passage_database(self, passages_data) -> dict[str, any]:
@@ -196,7 +209,9 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
 
         return db
 
-    def _generate_segments_from_outline(self, outline, passage_db: dict, style_notes) -> list[ScriptSegment]:
+    def _generate_segments_from_outline(
+        self, outline, passage_db: dict, style_notes
+    ) -> list[ScriptSegment]:
         """สร้าง segments จากโครงร่าง outline"""
         segments = []
 
@@ -204,15 +219,15 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
             segment_type = self._map_section_to_segment_type(section.section)
 
             # สร้างเนื้อหาตาม segment type
-            text = self._generate_segment_content(section, segment_type, passage_db, style_notes)
+            text = self._generate_segment_content(
+                section, segment_type, passage_db, style_notes
+            )
 
             # ประมาณเวลาเบื้องต้น
             est_seconds = self._estimate_segment_duration(text, section.est_seconds)
 
             segment = ScriptSegment(
-                segment_type=segment_type,
-                text=text,
-                est_seconds=est_seconds
+                segment_type=segment_type, text=text, est_seconds=est_seconds
             )
 
             segments.append(segment)
@@ -223,7 +238,9 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
         """แปลงชื่อ section จาก outline เป็น SegmentType"""
         return self.section_to_segment_type.get(section_name, SegmentType.TEACHING)
 
-    def _generate_segment_content(self, section, segment_type: SegmentType, passage_db: dict, style_notes) -> str:
+    def _generate_segment_content(
+        self, section, segment_type: SegmentType, passage_db: dict, style_notes
+    ) -> str:
         """สร้างเนื้อหา segment ตาม type"""
 
         if segment_type == SegmentType.HOOK:
@@ -249,7 +266,7 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
 
     def _generate_hook_content(self, section, style_notes) -> str:
         """สร้างเนื้อหา Hook segment"""
-        content_draft = getattr(section, 'content_draft', '')
+        content_draft = getattr(section, "content_draft", "")
         if content_draft:
             return f"{content_draft} เข้าใจไหมครับ?"
         else:
@@ -257,9 +274,11 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
 
     def _generate_problem_content(self, section, style_notes) -> str:
         """สร้างเนื้อหา Problem segment"""
-        key_points = getattr(section, 'key_points', [])
+        key_points = getattr(section, "key_points", [])
         if key_points:
-            return f"ปัญหาที่หลายคนพบเจอก็คือ {' '.join(key_points[:2])} ทำให้รู้สึกเหนื่อยและไม่สดชื่น"
+            return (
+                f"ปัญหาที่หลายคนพบเจอก็คือ {' '.join(key_points[:2])} ทำให้รู้สึกเหนื่อยและไม่สดชื่น"
+            )
         else:
             return "ปัญหาที่หลายคนเจอก็คือ ใจยังคิดวนเวียนแม้จะพยายามพักแล้ว"
 
@@ -269,8 +288,8 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
 
     def _generate_story_content(self, section, style_notes) -> str:
         """สร้างเนื้อหา Story segment"""
-        analogy_type = getattr(section, 'analogy_type', '')
-        beat_points = getattr(section, 'beat_points', [])
+        analogy_type = getattr(section, "analogy_type", "")
+        beat_points = getattr(section, "beat_points", [])
 
         if analogy_type and beat_points:
             return f"ลองคิดดูเหมือน{analogy_type} {' '.join(beat_points[:2])} นี่แหละครับที่เราจะมาเรียนรู้กัน"
@@ -282,15 +301,17 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
         content_parts = []
 
         # ใช้ sub_segments ถ้ามี
-        sub_segments = getattr(section, 'sub_segments', [])
+        sub_segments = getattr(section, "sub_segments", [])
         if sub_segments:
             for i, sub_segment in enumerate(sub_segments):
-                teaching_points = getattr(sub_segment, 'teaching_points', [])
+                teaching_points = getattr(sub_segment, "teaching_points", [])
                 if teaching_points:
-                    content_parts.append(f"ขั้นตอนที่ {i+1}: {teaching_points[0]}")
+                    content_parts.append(f"ขั้นตอนที่ {i + 1}: {teaching_points[0]}")
 
                     # เพิ่ม citation จาก placeholder ถ้ามี
-                    citation_placeholders = getattr(sub_segment, 'citation_placeholders', [])
+                    citation_placeholders = getattr(
+                        sub_segment, "citation_placeholders", []
+                    )
                     if citation_placeholders and citation_placeholders[0] in passage_db:
                         content_parts.append(f"[CIT:{citation_placeholders[0]}]")
 
@@ -307,16 +328,16 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
 
     def _generate_practice_content(self, section, passage_db: dict, style_notes) -> str:
         """สร้างเนื้อหา Practice segment"""
-        steps = getattr(section, 'steps', [])
+        steps = getattr(section, "steps", [])
         if steps:
-            numbered_steps = [f"{i+1}. {step}" for i, step in enumerate(steps)]
+            numbered_steps = [f"{i + 1}. {step}" for i, step in enumerate(steps)]
             return f"ลองปฏิบัติตามนี้ดูครับ: {' '.join(numbered_steps)}"
         else:
             return "ลองหลับตา หายใจเข้าลึกๆ และปล่อยออกช้าๆ สังเกตความรู้สึกที่เกิดขึ้น"
 
     def _generate_reflection_content(self, section, style_notes) -> str:
         """สร้างเนื้อหา Reflection segment"""
-        question = getattr(section, 'question', '')
+        question = getattr(section, "question", "")
         if question:
             return f"ตอนนี้ลองถามตัวเองว่า {question}"
         else:
@@ -324,7 +345,7 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
 
     def _generate_soft_cta_content(self, section, style_notes) -> str:
         """สร้างเนื้อหา Soft CTA segment"""
-        cta_phrase = getattr(section, 'cta_phrase', '')
+        cta_phrase = getattr(section, "cta_phrase", "")
         if cta_phrase:
             return cta_phrase
         else:
@@ -332,7 +353,7 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
 
     def _generate_closing_content(self, section, style_notes) -> str:
         """สร้างเนื้อหา Closing segment"""
-        closing_line = getattr(section, 'closing_line', '')
+        closing_line = getattr(section, "closing_line", "")
         if closing_line:
             return closing_line
         else:
@@ -341,8 +362,8 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
     def _estimate_segment_duration(self, text: str, outline_est_seconds: int) -> int:
         """ประมาณเวลา segment จากข้อความและค่าจาก outline"""
         # นับคำในข้อความ (ไม่รวม citations และ retention cues)
-        clean_text = re.sub(r'\[CIT:[^\]]+\]', '', text)
-        clean_text = re.sub(r'\([^)]+\)', '', clean_text)
+        clean_text = re.sub(r"\[CIT:[^\]]+\]", "", text)
+        clean_text = re.sub(r"\([^)]+\)", "", clean_text)
         word_count = len(clean_text.split())
 
         # คำนวณเวลาจากจำนวนคำ
@@ -354,7 +375,9 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
         else:
             return max(text_based_seconds, 5)  # อย่างน้อย 5 วินาที
 
-    def _add_retention_cues(self, segments: list[ScriptSegment], target_seconds: int) -> list[ScriptSegment]:
+    def _add_retention_cues(
+        self, segments: list[ScriptSegment], target_seconds: int
+    ) -> list[ScriptSegment]:
         """เพิ่ม retention cues ลงใน segments"""
         total_duration = sum(s.est_seconds for s in segments)
 
@@ -373,7 +396,9 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
 
         return segments
 
-    def _adjust_timing(self, segments: list[ScriptSegment], target_seconds: int) -> list[ScriptSegment]:
+    def _adjust_timing(
+        self, segments: list[ScriptSegment], target_seconds: int
+    ) -> list[ScriptSegment]:
         """ปรับเวลา segments ให้ตรงตามเป้าหมาย"""
         current_total = sum(s.est_seconds for s in segments)
         tolerance = target_seconds * 0.15
@@ -384,8 +409,11 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
         # ถ้าสั้นเกินไป ยืดเวลา teaching และ practice segments
         if current_total < target_seconds * 0.85:
             deficit = target_seconds - current_total
-            extendable_segments = [s for s in segments
-                                 if s.segment_type in [SegmentType.TEACHING, SegmentType.PRACTICE]]
+            extendable_segments = [
+                s
+                for s in segments
+                if s.segment_type in [SegmentType.TEACHING, SegmentType.PRACTICE]
+            ]
 
             if extendable_segments:
                 extra_per_segment = deficit // len(extendable_segments)
@@ -395,8 +423,11 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
         # ถ้ายาวเกินไป ลดเวลา segments ที่ไม่สำคัญ
         elif current_total > target_seconds * 1.15:
             excess = current_total - target_seconds
-            reducible_segments = [s for s in segments
-                                if s.segment_type not in [SegmentType.HOOK, SegmentType.CLOSING]]
+            reducible_segments = [
+                s
+                for s in segments
+                if s.segment_type not in [SegmentType.HOOK, SegmentType.CLOSING]
+            ]
 
             if reducible_segments:
                 reduce_per_segment = min(10, excess // len(reducible_segments))
@@ -406,13 +437,15 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
 
         return segments
 
-    def _validate_citations(self, segments: list[ScriptSegment], passage_db: dict) -> tuple[list[str], list[str]]:
+    def _validate_citations(
+        self, segments: list[ScriptSegment], passage_db: dict
+    ) -> tuple[list[str], list[str]]:
         """ตรวจสอบและรวบรวม citations"""
         citations_used = []
         unmatched_citations = []
 
         # หา citations ทั้งหมดใน segments
-        citation_pattern = r'\[CIT:([^\]]+)\]'
+        citation_pattern = r"\[CIT:([^\]]+)\]"
 
         for segment in segments:
             citations = re.findall(citation_pattern, segment.text)
@@ -432,33 +465,38 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
         # นับ retention cues
         interrupts_count = 0
         for segment in segments:
-            interrupts_count += len(re.findall(r'\([^)]+\)', segment.text))
+            interrupts_count += len(re.findall(r"\([^)]+\)", segment.text))
 
         # นับ teaching segments
-        teaching_segments = sum(1 for s in segments if s.segment_type == SegmentType.TEACHING)
+        teaching_segments = sum(
+            1 for s in segments if s.segment_type == SegmentType.TEACHING
+        )
 
         # นับขั้นตอน practice
         practice_steps_count = 0
         for segment in segments:
             if segment.segment_type == SegmentType.PRACTICE:
                 # นับหมายเลขขั้นตอน
-                practice_steps_count += len(re.findall(r'\d+\.', segment.text))
+                practice_steps_count += len(re.findall(r"\d+\.", segment.text))
 
         return ScriptMeta(
             reading_speed_wpm=self.avg_reading_speed,
             interrupts_count=interrupts_count,
             teaching_segments=teaching_segments,
-            practice_steps_count=practice_steps_count
+            practice_steps_count=practice_steps_count,
         )
 
     def _perform_quality_check(
-        self, segments: list[ScriptSegment], citations_used: list[str], target_seconds: int
+        self,
+        segments: list[ScriptSegment],
+        citations_used: list[str],
+        target_seconds: int,
     ) -> QualityCheck:
         """ตรวจสอบคุณภาพของสคริปต์"""
 
         # ตรวจสอบ citations
         unmatched_citations = []
-        citation_pattern = r'\[CIT:([^\]]+)\]'
+        citation_pattern = r"\[CIT:([^\]]+)\]"
         for segment in segments:
             citations = re.findall(citation_pattern, segment.text)
             for citation in citations:
@@ -471,7 +509,7 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
         teaching_has_citation = False
         for segment in segments:
             if segment.segment_type == SegmentType.TEACHING:
-                if '[CIT:' in segment.text:
+                if "[CIT:" in segment.text:
                     teaching_has_citation = True
                     break
 
@@ -497,11 +535,14 @@ class ScriptWriterAgent(BaseAgent[ScriptWriterInput, ScriptWriterOutput]):
             teaching_has_citation=teaching_has_citation,
             duration_within_range=duration_within_range,
             hook_within_8s=hook_within_8s,
-            no_prohibited_claims=no_prohibited_claims
+            no_prohibited_claims=no_prohibited_claims,
         )
 
     def _generate_warnings(
-        self, quality_check: QualityCheck, segments: list[ScriptSegment], input_data: ScriptWriterInput
+        self,
+        quality_check: QualityCheck,
+        segments: list[ScriptSegment],
+        input_data: ScriptWriterInput,
     ) -> list[str]:
         """สร้างคำเตือนและข้อเสนอแนะ"""
         warnings = []

--- a/src/agents/script_writer/model.py
+++ b/src/agents/script_writer/model.py
@@ -105,8 +105,7 @@ class ScriptWriterOutput(BaseModel):
     segments: list[ScriptSegment] = Field(description="ส่วนต่างๆ ของสคริปต์")
     citations_used: list[str] = Field(description="รายการ passage IDs ที่ใช้")
     unmatched_citations: list[str] = Field(
-        default_factory=list,
-        description="Citations ที่ไม่พบใน passages (ควรเป็นค่าว่าง)"
+        default_factory=list, description="Citations ที่ไม่พบใน passages (ควรเป็นค่าว่าง)"
     )
     duration_est_total: int = Field(description="เวลารวมประมาณการ (วินาที)")
     meta: ScriptMeta = Field(description="ข้อมูล metadata")

--- a/tests/test_research_retrieval_agent.py
+++ b/tests/test_research_retrieval_agent.py
@@ -360,4 +360,8 @@ class TestResearchRetrievalAgent:
             # ถ้าได้ ResearchRetrievalOutput ควรมี confidence ต่ำ
             assert isinstance(result, ResearchRetrievalOutput)
             assert result.coverage_assessment.confidence < 0.5  # ความมั่นใจต่ำ
-            assert len(result.warnings) > 0  # ควรมี warnings
+            assert result.warnings, "Expected warnings when no passages are found"
+            expected_warning_keys = {"insufficient_passages", "no_primary_passages"}
+            assert expected_warning_keys.intersection(set(result.warnings)), (
+                "Warnings should include insufficient passages information"
+            )

--- a/tests/test_script_writer_agent.py
+++ b/tests/test_script_writer_agent.py
@@ -6,8 +6,6 @@ Test cases สำหรับ ScriptWriterAgent
 import sys
 from pathlib import Path
 
-import pytest
-
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
@@ -46,7 +44,7 @@ class TestScriptWriterAgent:
     def create_sample_outline(self) -> ScriptOutlineOutput:
         """สร้าง sample outline สำหรับทดสอบ"""
         outline_agent = ScriptOutlineAgent()
-        
+
         input_data = ScriptOutlineInput(
             topic_title="ปล่อยวางความกังวลก่อนนอน",
             summary_bullets=[
@@ -58,18 +56,16 @@ class TestScriptWriterAgent:
             viewer_persona=ViewerPersona(
                 name="คนทำงานเมือง",
                 pain_points=["เครียดจากการทำงาน", "นอนไม่หลับ"],
-                desired_state="ใจสงบ นอนหลับสนิท"
+                desired_state="ใจสงบ นอนหลับสนิท",
             ),
             style_preferences=StylePreferences(
-                tone="อบอุ่น สงบ ไม่สั่งสอน",
-                avoid=["ศัพท์บาลีหนักเกินไป", "การตำหนิตัวผู้ชม"]
+                tone="อบอุ่น สงบ ไม่สั่งสอน", avoid=["ศัพท์บาลีหนักเกินไป", "การตำหนิตัวผู้ชม"]
             ),
             retention_goals=RetentionGoals(
-                hook_drop_max_pct=30,
-                mid_segment_break_every_sec=120
+                hook_drop_max_pct=30, mid_segment_break_every_sec=120
             ),
         )
-        
+
         return outline_agent.run(input_data)
 
     def create_sample_passages(self) -> PassageData:
@@ -85,10 +81,10 @@ class TestScriptWriterAgent:
                 relevance_final=0.9,
                 doctrinal_tags=["สติ", "สมาธิ"],
                 license="public_domain",
-                reason="เกี่ยวข้องกับการฝึกสติ"
+                reason="เกี่ยวข้องกับการฝึกสติ",
             ),
             Passage(
-                id="p210", 
+                id="p210",
                 source_name="อานาปานสติสูตร",
                 collection="พระสุตตันตปิฎก",
                 canonical_ref="MN 118",
@@ -96,11 +92,11 @@ class TestScriptWriterAgent:
                 thai_modernized="การสติดูลมหายใจที่พัฒนาแล้วจะทำให้ใจสงบ",
                 relevance_final=0.85,
                 doctrinal_tags=["อานาปานสติ", "สมาธิ"],
-                license="public_domain", 
-                reason="เกี่ยวข้องกับการหายใจและความสงบ"
-            )
+                license="public_domain",
+                reason="เกี่ยวข้องกับการหายใจและความสงบ",
+            ),
         ]
-        
+
         supportive_passages = [
             Passage(
                 id="p300",
@@ -112,31 +108,31 @@ class TestScriptWriterAgent:
                 relevance_final=0.7,
                 doctrinal_tags=["เวทนา", "วิปัสสนา"],
                 license="public_domain",
-                reason="อธิบายการสังเกตเวทนา"
+                reason="อธิบายการสังเกตเวทนา",
             )
         ]
-        
+
         return PassageData(primary=primary_passages, supportive=supportive_passages)
 
     def test_run_basic_functionality(self):
         """ทดสอบการทำงานพื้นฐานของ agent"""
         outline = self.create_sample_outline()
         passages = self.create_sample_passages()
-        
+
         input_data = ScriptWriterInput(
             outline=outline,
             passages=passages,
             style_notes=StyleNotes(
                 tone="อบอุ่น สงบ ไม่สั่งสอน",
                 voice="เป็นกันเอง สุภาพ ใช้คำว่า เรา/คุณ",
-                avoid=["ศัพท์บาลีติดกันหลายคำ", "การชี้นำผลลัพธ์แน่นอน"]
+                avoid=["ศัพท์บาลีติดกันหลายคำ", "การชี้นำผลลัพธ์แน่นอน"],
             ),
             target_seconds=600,
-            language="th"
+            language="th",
         )
-        
+
         result = self.agent.run(input_data)
-        
+
         # ตรวจสอบโครงสร้างพื้นฐาน
         assert isinstance(result, ScriptWriterOutput)
         assert result.topic == outline.topic
@@ -147,25 +143,21 @@ class TestScriptWriterAgent:
         """ทดสอบโครงสร้างของ segments"""
         outline = self.create_sample_outline()
         passages = self.create_sample_passages()
-        
+
         input_data = ScriptWriterInput(
             outline=outline,
             passages=passages,
-            style_notes=StyleNotes(
-                tone="อบอุ่น สงบ",
-                voice="เป็นกันเอง",
-                avoid=[]
-            ),
-            target_seconds=600
+            style_notes=StyleNotes(tone="อบอุ่น สงบ", voice="เป็นกันเอง", avoid=[]),
+            target_seconds=600,
         )
-        
+
         result = self.agent.run(input_data)
-        
+
         # ตรวจสอบว่ามี segment types ที่จำเป็น
         segment_types = [s.segment_type for s in result.segments]
         assert SegmentType.HOOK in segment_types
         assert SegmentType.TEACHING in segment_types
-        
+
         # ตรวจสอบว่าแต่ละ segment มีข้อมูลครบ
         for segment in result.segments:
             assert segment.text.strip() != ""
@@ -176,24 +168,22 @@ class TestScriptWriterAgent:
         """ทดสอบข้อกำหนดของ Hook segment"""
         outline = self.create_sample_outline()
         passages = self.create_sample_passages()
-        
+
         input_data = ScriptWriterInput(
             outline=outline,
             passages=passages,
-            style_notes=StyleNotes(
-                tone="อบอุ่น",
-                voice="เป็นกันเอง", 
-                avoid=[]
-            ),
-            target_seconds=600
+            style_notes=StyleNotes(tone="อบอุ่น", voice="เป็นกันเอง", avoid=[]),
+            target_seconds=600,
         )
-        
+
         result = self.agent.run(input_data)
-        
+
         # หา Hook segments
-        hook_segments = [s for s in result.segments if s.segment_type == SegmentType.HOOK]
+        hook_segments = [
+            s for s in result.segments if s.segment_type == SegmentType.HOOK
+        ]
         assert len(hook_segments) > 0
-        
+
         # ตรวจสอบ Hook ไม่เกิน 8 วินาที
         for hook in hook_segments:
             assert hook.est_seconds <= 8
@@ -202,56 +192,50 @@ class TestScriptWriterAgent:
         """ทดสอบว่า teaching segments มี citations"""
         outline = self.create_sample_outline()
         passages = self.create_sample_passages()
-        
+
         input_data = ScriptWriterInput(
             outline=outline,
             passages=passages,
-            style_notes=StyleNotes(
-                tone="อบอุ่น",
-                voice="เป็นกันเอง",
-                avoid=[]
-            ),
-            target_seconds=600
+            style_notes=StyleNotes(tone="อบอุ่น", voice="เป็นกันเอง", avoid=[]),
+            target_seconds=600,
         )
-        
+
         result = self.agent.run(input_data)
-        
+
         # หา Teaching segments
-        teaching_segments = [s for s in result.segments if s.segment_type == SegmentType.TEACHING]
-        
+        teaching_segments = [
+            s for s in result.segments if s.segment_type == SegmentType.TEACHING
+        ]
+
         # อย่างน้อยต้องมี 1 teaching segment ที่มี citation
         has_citation = False
         for segment in teaching_segments:
             if "[CIT:" in segment.text:
                 has_citation = True
                 break
-        
+
         assert has_citation, "Teaching segments ควรมี citations"
 
     def test_citations_validation(self):
         """ทดสอบการตรวจสอบ citations"""
         outline = self.create_sample_outline()
         passages = self.create_sample_passages()
-        
+
         input_data = ScriptWriterInput(
             outline=outline,
             passages=passages,
-            style_notes=StyleNotes(
-                tone="อบอุ่น",
-                voice="เป็นกันเอง",
-                avoid=[]
-            ),
-            target_seconds=600
+            style_notes=StyleNotes(tone="อบอุ่น", voice="เป็นกันเอง", avoid=[]),
+            target_seconds=600,
         )
-        
+
         result = self.agent.run(input_data)
-        
+
         # ตรวจสอบว่า citations ที่ใช้มีอยู่ใน passages
         passage_ids = [p.id for p in passages.primary + passages.supportive]
-        
+
         for citation_id in result.citations_used:
             assert citation_id in passage_ids, f"Citation {citation_id} ไม่มีใน passages"
-        
+
         # ตรวจสอบว่า unmatched_citations ควรเป็นค่าว่าง
         assert len(result.unmatched_citations) == 0
 
@@ -259,28 +243,25 @@ class TestScriptWriterAgent:
         """ทดสอบการเพิ่ม retention cues"""
         outline = self.create_sample_outline()
         passages = self.create_sample_passages()
-        
+
         input_data = ScriptWriterInput(
             outline=outline,
             passages=passages,
-            style_notes=StyleNotes(
-                tone="อบอุ่น",
-                voice="เป็นกันเอง",
-                avoid=[]
-            ),
-            target_seconds=600
+            style_notes=StyleNotes(tone="อบอุ่น", voice="เป็นกันเอง", avoid=[]),
+            target_seconds=600,
         )
-        
+
         result = self.agent.run(input_data)
-        
+
         # ตรวจสอบว่ามี retention cues
         total_cues = 0
         for segment in result.segments:
             # นับจำนวน retention cues (ในวงเล็บ)
             import re
-            cues = re.findall(r'\([^)]+\)', segment.text)
+
+            cues = re.findall(r"\([^)]+\)", segment.text)
             total_cues += len(cues)
-        
+
         assert total_cues > 0, "ควรมี retention cues"
         assert result.meta.interrupts_count == total_cues
 
@@ -288,96 +269,86 @@ class TestScriptWriterAgent:
         """ทดสอบการควบคุมระยะเวลา"""
         outline = self.create_sample_outline()
         passages = self.create_sample_passages()
-        
+
         target_seconds = 600
         input_data = ScriptWriterInput(
             outline=outline,
             passages=passages,
-            style_notes=StyleNotes(
-                tone="อบอุ่น",
-                voice="เป็นกันเอง",
-                avoid=[]
-            ),
-            target_seconds=target_seconds
+            style_notes=StyleNotes(tone="อบอุ่น", voice="เป็นกันเอง", avoid=[]),
+            target_seconds=target_seconds,
         )
-        
+
         result = self.agent.run(input_data)
-        
+
         # ตรวจสอบระยะเวลารวม
         tolerance = target_seconds * 0.15  # ±15%
-        assert abs(result.duration_est_total - target_seconds) <= tolerance * 2  # ยอมรับความคลาดเคลื่อนสูงในการทดสอบ
+        assert (
+            abs(result.duration_est_total - target_seconds) <= tolerance * 2
+        )  # ยอมรับความคลาดเคลื่อนสูงในการทดสอบ
 
     def test_quality_check_completeness(self):
         """ทดสอบความสมบูรณ์ของ quality check"""
         outline = self.create_sample_outline()
         passages = self.create_sample_passages()
-        
+
         input_data = ScriptWriterInput(
             outline=outline,
             passages=passages,
-            style_notes=StyleNotes(
-                tone="อบอุ่น",
-                voice="เป็นกันเอง",
-                avoid=[]
-            ),
-            target_seconds=600
+            style_notes=StyleNotes(tone="อบอุ่น", voice="เป็นกันเอง", avoid=[]),
+            target_seconds=600,
         )
-        
+
         result = self.agent.run(input_data)
-        
+
         # ตรวจสอบว่ามี quality check ครบถ้วน
         qc = result.quality_check
-        assert hasattr(qc, 'citations_valid')
-        assert hasattr(qc, 'teaching_has_citation')
-        assert hasattr(qc, 'duration_within_range')
-        assert hasattr(qc, 'hook_within_8s')
-        assert hasattr(qc, 'no_prohibited_claims')
+        assert hasattr(qc, "citations_valid")
+        assert hasattr(qc, "teaching_has_citation")
+        assert hasattr(qc, "duration_within_range")
+        assert hasattr(qc, "hook_within_8s")
+        assert hasattr(qc, "no_prohibited_claims")
 
     def test_meta_info_accuracy(self):
         """ทดสอบความถูกต้องของ meta info"""
         outline = self.create_sample_outline()
         passages = self.create_sample_passages()
-        
+
         input_data = ScriptWriterInput(
             outline=outline,
             passages=passages,
-            style_notes=StyleNotes(
-                tone="อบอุ่น",
-                voice="เป็นกันเอง",
-                avoid=[]
-            ),
-            target_seconds=600
+            style_notes=StyleNotes(tone="อบอุ่น", voice="เป็นกันเอง", avoid=[]),
+            target_seconds=600,
         )
-        
+
         result = self.agent.run(input_data)
-        
+
         meta = result.meta
-        
+
         # ตรวจสอบ reading speed อยู่ในช่วงที่เหมาะสม
         assert 100 <= meta.reading_speed_wpm <= 200
-        
+
         # ตรวจสอบจำนวน teaching segments
-        actual_teaching_segments = len([s for s in result.segments if s.segment_type == SegmentType.TEACHING])
+        actual_teaching_segments = len(
+            [s for s in result.segments if s.segment_type == SegmentType.TEACHING]
+        )
         assert meta.teaching_segments == actual_teaching_segments
 
     def test_prohibited_claims_detection(self):
         """ทดสอบการตรวจจับคำที่ห้ามใช้"""
         outline = self.create_sample_outline()
         passages = self.create_sample_passages()
-        
+
         input_data = ScriptWriterInput(
             outline=outline,
             passages=passages,
             style_notes=StyleNotes(
-                tone="อบอุ่น",
-                voice="เป็นกันเอง",
-                avoid=["การยืนยันผลลัพธ์แน่นอน"]
+                tone="อบอุ่น", voice="เป็นกันเอง", avoid=["การยืนยันผลลัพธ์แน่นอน"]
             ),
-            target_seconds=600
+            target_seconds=600,
         )
-        
+
         result = self.agent.run(input_data)
-        
+
         # ตรวจสอบว่าไม่มีคำต้องห้าม
         prohibited_found = False
         for segment in result.segments:
@@ -385,61 +356,57 @@ class TestScriptWriterAgent:
                 if claim in segment.text:
                     prohibited_found = True
                     break
-        
+
         # Quality check ควรสะท้อนการตรวจสอบนี้
         assert result.quality_check.no_prohibited_claims == (not prohibited_found)
 
     def test_input_validation(self):
         """ทดสอบการตรวจสอบข้อมูลนำเข้า"""
         outline = self.create_sample_outline()
-        
+
         # ทดสอบกรณีไม่มี passages
         input_data = ScriptWriterInput(
             outline=outline,
             passages=PassageData(primary=[], supportive=[]),
-            style_notes=StyleNotes(
-                tone="อบอุ่น",
-                voice="เป็นกันเอง",
-                avoid=[]
-            ),
-            target_seconds=600
+            style_notes=StyleNotes(tone="อบอุ่น", voice="เป็นกันเอง", avoid=[]),
+            target_seconds=600,
         )
-        
+
         result = self.agent.run(input_data)
-        
+
         # ควรได้ warning หรือ error
-        assert len(result.warnings) > 0
+        assert result.warnings, "Expected warnings when no passages are provided"
+        assert any(
+            "passage" in warning.lower() or "ไม่พบ" in warning
+            for warning in result.warnings
+        ), "Warnings should mention missing passages"
 
     def test_different_target_durations(self):
         """ทดสอบการปรับตัวตามระยะเวลาเป้าหมายที่แตกต่าง"""
         outline = self.create_sample_outline()
         passages = self.create_sample_passages()
-        
-        style_notes = StyleNotes(
-            tone="อบอุ่น",
-            voice="เป็นกันเอง",
-            avoid=[]
-        )
-        
+
+        style_notes = StyleNotes(tone="อบอุ่น", voice="เป็นกันเอง", avoid=[])
+
         # ทดสอบเป้าหมาย 8 นาที
         input_short = ScriptWriterInput(
             outline=outline,
             passages=passages,
             style_notes=style_notes,
-            target_seconds=480
+            target_seconds=480,
         )
-        
+
         # ทดสอบเป้าหมาย 12 นาที
         input_long = ScriptWriterInput(
             outline=outline,
             passages=passages,
             style_notes=style_notes,
-            target_seconds=720
+            target_seconds=720,
         )
-        
+
         result_short = self.agent.run(input_short)
         result_long = self.agent.run(input_long)
-        
+
         # สคริปต์ยาวควรมีระยะเวลานานกว่า
         assert result_long.duration_est_total > result_short.duration_est_total
 
@@ -447,20 +414,16 @@ class TestScriptWriterAgent:
         """ทดสอบการสร้างคำเตือน"""
         outline = self.create_sample_outline()
         passages = self.create_sample_passages()
-        
+
         input_data = ScriptWriterInput(
             outline=outline,
             passages=passages,
-            style_notes=StyleNotes(
-                tone="อบอุ่น",
-                voice="เป็นกันเอง",
-                avoid=[]
-            ),
-            target_seconds=300  # เป้าหมายสั้นมาก เพื่อให้เกิด warning
+            style_notes=StyleNotes(tone="อบอุ่น", voice="เป็นกันเอง", avoid=[]),
+            target_seconds=300,  # เป้าหมายสั้นมาก เพื่อให้เกิด warning
         )
-        
+
         result = self.agent.run(input_data)
-        
+
         # ควรมี warnings เนื่องจากเป้าหมายเวลาสั้น
         assert isinstance(result.warnings, list)
 
@@ -468,25 +431,24 @@ class TestScriptWriterAgent:
         """ทดสอบว่าครอบคลุม segment types ที่สำคัญ"""
         outline = self.create_sample_outline()
         passages = self.create_sample_passages()
-        
+
         input_data = ScriptWriterInput(
             outline=outline,
             passages=passages,
-            style_notes=StyleNotes(
-                tone="อบอุ่น",
-                voice="เป็นกันเอง",
-                avoid=[]
-            ),
-            target_seconds=600
+            style_notes=StyleNotes(tone="อบอุ่น", voice="เป็นกันเอง", avoid=[]),
+            target_seconds=600,
         )
-        
+
         result = self.agent.run(input_data)
-        
+
         segment_types = [s.segment_type for s in result.segments]
-        
+
         # ตรวจสอบว่ามี segment types ที่หลากหลาย
         assert len(set(segment_types)) >= 3  # อย่างน้อย 3 ประเภท
-        
+
         # Hook และ Closing ควรมี
         assert SegmentType.HOOK in segment_types
-        assert SegmentType.CLOSING in segment_types or SegmentType.TEACHING in segment_types
+        assert (
+            SegmentType.CLOSING in segment_types
+            or SegmentType.TEACHING in segment_types
+        )


### PR DESCRIPTION
## Summary
- tighten the ScriptWriterAgent input validation test to assert for warning content about missing passages
- ensure ResearchRetrievalAgent empty-passage handling checks for specific warning keys instead of only length
- apply Ruff auto-formatting updates across agents and scripts per repository style

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d56fcaa464832082dca8bd77234150