### PR TITLE
Fix lint issues in doctrine validator

### DIFF
--- a/src/agents/doctrine_validator/agent.py
+++ b/src/agents/doctrine_validator/agent.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from difflib import SequenceMatcher
 
 from automation_core.base_agent import BaseAgent
@@ -155,7 +155,7 @@ class DoctrineValidatorAgent(
             )
 
             output = DoctrineValidatorOutput(
-                validated_at=datetime.now(timezone.utc).isoformat(),
+                validated_at=datetime.now(UTC).isoformat(),
                 strictness=input_data.strictness,
                 segments=processed_segments,
                 summary=Summary(

--- a/src/agents/doctrine_validator/model.py
+++ b/src/agents/doctrine_validator/model.py
@@ -34,7 +34,7 @@ class SegmentType(StrEnum):
     OTHER = "other"
 
     @classmethod
-    def from_raw(cls, value: str) -> "SegmentType":
+    def from_raw(cls, value: str) -> SegmentType:
         """สร้าง SegmentType จาก string แบบยืดหยุ่น"""
 
         normalized = (value or "").strip().lower()


### PR DESCRIPTION
## Summary
- use the `datetime.UTC` alias when generating timestamps in the doctrine validator agent
- drop unnecessary string literal annotation around `SegmentType.from_raw`

## Testing
- ruff check
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5804baaa88320bc0ead4ba03deb7b