### PR TITLE
Format doctrine validator files

### DIFF
--- a/src/agents/doctrine_validator/agent.py
+++ b/src/agents/doctrine_validator/agent.py
@@ -94,9 +94,7 @@ class DoctrineValidatorAgent(
                 )
 
                 if segment_result.status == SegmentStatus.MISSING_CITATION:
-                    global_warnings.append(
-                        f"segment {index} มีเนื้อหาสอนแต่ไม่มี citation"
-                    )
+                    global_warnings.append(f"segment {index} มีเนื้อหาสอนแต่ไม่มี citation")
                 if segment_result.status == SegmentStatus.UNVERIFIABLE:
                     global_warnings.append(
                         f"segment {index} ไม่สามารถตรวจสอบกับ passages ได้"
@@ -106,9 +104,7 @@ class DoctrineValidatorAgent(
                         f"segment {index} มีเนื้อหาไม่ตรงกับ passages ที่อ้าง"
                     )
                 if segment_result.status == SegmentStatus.HALLUCINATION:
-                    global_warnings.append(
-                        f"segment {index} มีใจความที่ไม่พบใน passages"
-                    )
+                    global_warnings.append(f"segment {index} มีใจความที่ไม่พบใน passages")
 
                 unmatched_citation_count += sum(
                     1 for warn in segment_result.warnings if "ไม่พบ" in warn
@@ -122,7 +118,10 @@ class DoctrineValidatorAgent(
                         )
                     )
 
-                if segment_result.matched_passages and normalized_type == SegmentType.TEACHING:
+                if (
+                    segment_result.matched_passages
+                    and normalized_type == SegmentType.TEACHING
+                ):
                     teaching_with_citation += 1
 
                 processed_segments.append(segment_result)
@@ -176,16 +175,16 @@ class DoctrineValidatorAgent(
                     self_check=SelfCheck(
                         ok_ratio=round(ok_ratio, 2),
                         no_unmatched_citation=unmatched_citation_count == 0,
-                        no_missing_citation=
-                            summary_counter[SegmentStatus.MISSING_CITATION] == 0,
+                        no_missing_citation=summary_counter[
+                            SegmentStatus.MISSING_CITATION
+                        ]
+                        == 0,
                     ),
                 ),
                 warnings=global_warnings,
             )
 
-            logger.info(
-                "ตรวจสอบสคริปต์เสร็จสิ้น %s segments", output.summary.total
-            )
+            logger.info("ตรวจสอบสคริปต์เสร็จสิ้น %s segments", output.summary.total)
             return output
         except Exception as exc:  # pragma: no cover - unexpected error path
             logger.exception("เกิดข้อผิดพลาดระหว่างการตรวจสอบ")
@@ -233,7 +232,9 @@ class DoctrineValidatorAgent(
         # Sensitive phrase detection
         if check_sensitive:
             lowered = segment.text.lower()
-            flagged = [phrase for phrase in SENSITIVE_PHRASES if phrase.lower() in lowered]
+            flagged = [
+                phrase for phrase in SENSITIVE_PHRASES if phrase.lower() in lowered
+            ]
             for phrase in flagged:
                 warnings.append(f"พบถ้อยคำสุ่มเสี่ยง: '{phrase}'")
 
@@ -245,7 +246,11 @@ class DoctrineValidatorAgent(
                 status = SegmentStatus.UNVERIFIABLE
                 continue
 
-            if strictness == "strict" and passage.license and passage.license != "public_domain":
+            if (
+                strictness == "strict"
+                and passage.license
+                and passage.license != "public_domain"
+            ):
                 warnings.append(
                     f"Citation ID '{cit}' มี license '{passage.license}' ไม่ใช่ public_domain"
                 )
@@ -274,7 +279,10 @@ class DoctrineValidatorAgent(
             avg_similarity = sum(similarity_records) / len(similarity_records)
             notes = f"similarity_avg={avg_similarity:.2f}"
 
-        if status == SegmentStatus.UNVERIFIABLE and normalized_type == SegmentType.TEACHING:
+        if (
+            status == SegmentStatus.UNVERIFIABLE
+            and normalized_type == SegmentType.TEACHING
+        ):
             suggestions = "ตรวจสอบว่ามีการอ้างอิง passages ที่ถูกต้อง"
 
         return SegmentValidation(

--- a/src/agents/doctrine_validator/model.py
+++ b/src/agents/doctrine_validator/model.py
@@ -61,13 +61,9 @@ class Passage(BaseModel):
 
     id: str = Field(description="รหัสอ้างอิง")
     original_text: str = Field(description="ข้อความต้นฉบับ")
-    thai_modernized: str | None = Field(
-        default=None, description="คำแปลไทยร่วมสมัย"
-    )
+    thai_modernized: str | None = Field(default=None, description="คำแปลไทยร่วมสมัย")
     doctrinal_tags: list[str] = Field(default_factory=list, description="แท็กหลักธรรม")
-    canonical_ref: str | None = Field(
-        default=None, description="เลขอ้างอิงในพระไตรปิฎก"
-    )
+    canonical_ref: str | None = Field(default=None, description="เลขอ้างอิงในพระไตรปิฎก")
     license: str | None = Field(default=None, description="สถานะลิขสิทธิ์")
 
 
@@ -91,9 +87,7 @@ class Passages(BaseModel):
 class DoctrineValidatorInput(BaseModel):
     """Input สำหรับ DoctrineValidatorAgent"""
 
-    script_segments: list[ScriptSegment] = Field(
-        description="รายการ segment ของสคริปต์"
-    )
+    script_segments: list[ScriptSegment] = Field(description="รายการ segment ของสคริปต์")
     passages: Passages = Field(description="ข้อความอ้างอิง")
     strictness: Literal["normal", "strict"] = Field(
         default="normal", description="ระดับความเข้มงวด"
@@ -101,9 +95,7 @@ class DoctrineValidatorInput(BaseModel):
     ignore_segments: list[int] = Field(
         default_factory=list, description="ดัชนี segment ที่ข้ามการตรวจ"
     )
-    check_sensitive: bool = Field(
-        default=False, description="ตรวจคำที่สุ่มเสี่ยงหรือไม่"
-    )
+    check_sensitive: bool = Field(default=False, description="ตรวจคำที่สุ่มเสี่ยงหรือไม่")
 
     @field_validator("script_segments")
     @classmethod


### PR DESCRIPTION
## Summary
- apply Ruff formatter to Doctrine Validator agent and model modules to satisfy formatting guidelines

## Testing
- ruff format --check .

------
https://chatgpt.com/codex/tasks/task_e_68d5859e8eb48320a452c5e79cecf323