### PR TITLE
Fix ruff issues in doctrine validator agent

### DIFF
--- a/src/agents/doctrine_validator/agent.py
+++ b/src/agents/doctrine_validator/agent.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import logging
 import re
 from datetime import UTC, datetime
+
 from sentence_transformers import SentenceTransformer
 from sklearn.metrics.pairwise import cosine_similarity
-import numpy as np
 
 from automation_core.base_agent import BaseAgent
 
@@ -42,16 +42,19 @@ SENSITIVE_PHRASES = [
 
 
 class DoctrineValidatorAgent(
+    BaseAgent[DoctrineValidatorInput, DoctrineValidatorOutput | ErrorResponse]
+):
+    """Agent สำหรับตรวจสอบความถูกต้องของสคริปต์ตามหลักธรรม"""
+
     _embedding_model = None
 
     @classmethod
     def _get_embedding_model(cls):
         if cls._embedding_model is None:
-            cls._embedding_model = SentenceTransformer("paraphrase-multilingual-MiniLM-L12-v2")
+            cls._embedding_model = SentenceTransformer(
+                "paraphrase-multilingual-MiniLM-L12-v2"
+            )
         return cls._embedding_model
-    BaseAgent[DoctrineValidatorInput, DoctrineValidatorOutput | ErrorResponse]
-):
-    """Agent สำหรับตรวจสอบความถูกต้องของสคริปต์ตามหลักธรรม"""
 
     def __init__(self) -> None:
         super().__init__(

--- a/src/agents/doctrine_validator/model.py
+++ b/src/agents/doctrine_validator/model.py
@@ -69,7 +69,7 @@ class Passage(BaseModel):
 
 class Passages(BaseModel):
     @model_validator(mode="after")
-    def ensure_unique_ids_across_lists(self) -> "Passages":
+    def ensure_unique_ids_across_lists(self) -> Passages:
         primary_ids = {p.id for p in self.primary}
         supportive_ids = {p.id for p in self.supportive}
         intersecting_ids = primary_ids.intersection(supportive_ids)


### PR DESCRIPTION
## Summary
- restore a valid class definition for `DoctrineValidatorAgent` and remove unused imports flagged by Ruff
- ensure the embedding model loader follows Ruff formatting suggestions
- adjust the `Passages.ensure_unique_ids_across_lists` return annotation to avoid unnecessary string literal quoting

## Testing
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68d592a664f08320a8cbdc8c38111489