### PR TITLE
Add sentence-transformers dependency for CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -e .
-          pip install ruff mypy
+          pip install -e ".[dev]"
 
       - name: Ruff check
         run: ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ dev = [
     "mypy>=1.0.0",
     "mkdocs>=1.5.0",
     "mkdocs-material>=9.0.0",
+    "torch>=2.1,<2.6",
+    "sentence-transformers>=2.2.2",
 ]
 ml = [
     "scikit-learn>=1.3.0",


### PR DESCRIPTION
## Summary
- add `sentence-transformers` and a compatible `torch` pin to the development dependency set
- update the CI workflow to install the project with development extras so required ML packages are available during checks

## Testing
- not run (PyTorch CPU wheel download exceeds available session resources)

------
https://chatgpt.com/codex/tasks/task_e_68d59b75c9c4832096cacf36758fbbfc