### PR TITLE
Fix lint warnings from CI

### DIFF
--- a/src/agents/localization_subtitle/agent.py
+++ b/src/agents/localization_subtitle/agent.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import json
 import re
 import textwrap
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Any, Iterable, Protocol
+from typing import Any, Protocol
 
 from automation_core.base_agent import BaseAgent
 from automation_core.prompt_loader import get_prompt_path, load_prompt

--- a/src/agents/localization_subtitle/model.py
+++ b/src/agents/localization_subtitle/model.py
@@ -130,7 +130,7 @@ class LocalizationSubtitleOutput(BaseModel):
         return " ".join(words)
 
     @model_validator(mode="after")
-    def validate_structure(self) -> "LocalizationSubtitleOutput":
+    def validate_structure(self) -> LocalizationSubtitleOutput:
         blocks = [
             block.strip()
             for block in re.split(r"\n\s*\n", self.srt.strip())


### PR DESCRIPTION
## Summary
- import `Iterable` from `collections.abc` in the localization subtitle agent to satisfy pyupgrade
- remove unnecessary string literal around the return type of `validate_structure`

## Testing
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68d5af958d9083209d1fd3b6fc863a70