### PR TITLE
Enable hallucination detection without embeddings

### DIFF
--- a/src/agents/doctrine_validator/agent.py
+++ b/src/agents/doctrine_validator/agent.py
@@ -252,9 +252,12 @@ class DoctrineValidatorAgent(
                 similarity = self._compute_similarity(segment.text, passage)
                 if similarity > best_similarity:
                     best_similarity = similarity
-            if best_similarity < 0.6 and embedding_available:
+            if best_similarity < 0.6:
                 status = SegmentStatus.HALLUCINATION
-                notes = f"ไม่พบใจความใน passages (similarity_max={best_similarity:.2f})"
+                detail = "ไม่พบใจความใน passages"
+                if not embedding_available:
+                    detail += " (ใช้การเทียบคำแบบพื้นฐาน)"
+                notes = f"{detail} (similarity_max={best_similarity:.2f})"
             else:
                 status = SegmentStatus.MISSING_CITATION
                 suggestions = "เพิ่ม citation ให้กับใจความสอนหลัก"

--- a/tests/test_doctrine_validator_agent.py
+++ b/tests/test_doctrine_validator_agent.py
@@ -102,10 +102,11 @@ class TestDoctrineValidatorAgent:
         result = self.agent.run(input_data)
         statuses = [segment.status for segment in result.segments]
 
-        assert statuses[1] == SegmentStatus.MISSING_CITATION
+        assert statuses[1] == SegmentStatus.HALLUCINATION
         assert statuses[2] == SegmentStatus.UNVERIFIABLE
         assert any("สุ่มเสี่ยง" in warn for warn in result.segments[2].warnings)
-        assert result.summary.missing_citation == 1
+        assert result.summary.hallucination == 1
+        assert result.summary.missing_citation == 0
         assert result.summary.unverifiable >= 1
         assert result.summary.total == 3
 


### PR DESCRIPTION
## Summary
- flag teaching segments as hallucinations when citations are missing and lexical similarity is low even without embeddings
- annotate fallback similarity notes for transparency when sentence-transformers is unavailable
- adjust doctrinal validator tests to expect hallucination status under the lexical fallback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d5b14d04848320940c1ae888cab5f7