### PR TITLE
Fix formatting for localization subtitle CI failure

### DIFF
--- a/src/agents/doctrine_validator/agent.py
+++ b/src/agents/doctrine_validator/agent.py
@@ -418,12 +418,8 @@ class DoctrineValidatorAgent(
         numerator = sum(
             source_counter[token] * target_counter[token] for token in intersection
         )
-        source_norm = math.sqrt(
-            sum(value * value for value in source_counter.values())
-        )
-        target_norm = math.sqrt(
-            sum(value * value for value in target_counter.values())
-        )
+        source_norm = math.sqrt(sum(value * value for value in source_counter.values()))
+        target_norm = math.sqrt(sum(value * value for value in target_counter.values()))
         if source_norm == 0 or target_norm == 0:
             return 0.0
         return numerator / (source_norm * target_norm)

--- a/src/agents/localization_subtitle/model.py
+++ b/src/agents/localization_subtitle/model.py
@@ -78,13 +78,9 @@ class LocalizationSubtitleMeta(BaseModel):
     """Metadata calculated for the generated subtitle."""
 
     lines: int = Field(ge=1, description="จำนวนบรรทัดทั้งหมดในไฟล์ SRT")
-    duration_total: float = Field(
-        ge=0, description="ระยะเวลารวมตั้งแต่เริ่มจนจบบล็อกสุดท้าย"
-    )
+    duration_total: float = Field(ge=0, description="ระยะเวลารวมตั้งแต่เริ่มจนจบบล็อกสุดท้าย")
     segments_count: int = Field(ge=1, description="จำนวนบล็อก subtitle")
-    time_continuity_ok: bool = Field(
-        description="เวลาของแต่ละบล็อกต่อเนื่องกันโดยไม่มีช่องว่าง"
-    )
+    time_continuity_ok: bool = Field(description="เวลาของแต่ละบล็อกต่อเนื่องกันโดยไม่มีช่องว่าง")
     no_overlap: bool = Field(description="ไม่มีการซ้อนทับของเวลา")
     no_empty_line: bool = Field(description="ไม่มีบรรทัดข้อความว่างในแต่ละบล็อก")
     self_check: bool = Field(
@@ -179,7 +175,9 @@ class LocalizationSubtitleOutput(BaseModel):
                 first_start = start_seconds
 
             if last_end is not None:
-                if not math.isclose(start_seconds, last_end, rel_tol=1e-4, abs_tol=1e-3):
+                if not math.isclose(
+                    start_seconds, last_end, rel_tol=1e-4, abs_tol=1e-3
+                ):
                     continuity_ok = False
                 if start_seconds < last_end - 1e-3:
                     no_overlap = False

--- a/tests/test_localization_subtitle_agent.py
+++ b/tests/test_localization_subtitle_agent.py
@@ -68,9 +68,7 @@ class TestLocalizationSubtitleAgent:
 
         # Validate SRT structure
         blocks = [
-            block.strip()
-            for block in output.srt.strip().split("\n\n")
-            if block.strip()
+            block.strip() for block in output.srt.strip().split("\n\n") if block.strip()
         ]
         assert len(blocks) == 4
         for idx, block in enumerate(blocks, start=1):
@@ -88,7 +86,9 @@ class TestLocalizationSubtitleAgent:
         assert output.meta.self_check is True
 
         # Summary should respect length requirements
-        summary_words = [w for w in re.split(r'\s+', output.english_summary.strip()) if w]
+        summary_words = [
+            w for w in re.split(r"\s+", output.english_summary.strip()) if w
+        ]
         assert 50 <= len(summary_words) <= 100
         assert output.warnings == []
 


### PR DESCRIPTION
## Summary
- format the doctrine validator agent to align with Black's expectations
- reflow localization subtitle models and tests to resolve style deviations

## Testing
- pytest tests/test_localization_subtitle_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68d5e94beb808320a9186e2100d080b0