### PR TITLE
Format files to satisfy black

### DIFF
--- a/src/agents/doctrine_validator/agent.py
+++ b/src/agents/doctrine_validator/agent.py
@@ -256,9 +256,7 @@ class DoctrineValidatorAgent(
             status = SegmentStatus.HALLUCINATION
             detail = "ไม่พบใจความใน passages"
             if best_similarity >= 0.6:
-                detail = (
-                    "พบใจความใกล้เคียงใน passages แต่ไม่มี citation"
-                )
+                detail = "พบใจความใกล้เคียงใน passages แต่ไม่มี citation"
                 suggestions = "เพิ่ม citation ให้กับใจความสอนหลัก"
             elif not embedding_available:
                 detail += " (ใช้การเทียบคำแบบพื้นฐาน)"

--- a/src/agents/script_outline/agent.py
+++ b/src/agents/script_outline/agent.py
@@ -423,9 +423,9 @@ class ScriptOutlineAgent(BaseAgent[ScriptOutlineInput, ScriptOutlineOutput]):
             teaching_points=content["points"],
             concept_links=content["concepts"],
             citation_placeholders=[f"p{123 + index * 100}"],
-            retention_tags=["guided_breath"]
-            if "อานาปาน" in concept
-            else ["soft_pause"],
+            retention_tags=(
+                ["guided_breath"] if "อานาปาน" in concept else ["soft_pause"]
+            ),
         )
 
     def _generate_practice_steps(self, input_data: ScriptOutlineInput) -> list[str]:

--- a/tests/test_research_retrieval_agent.py
+++ b/tests/test_research_retrieval_agent.py
@@ -362,6 +362,6 @@ class TestResearchRetrievalAgent:
             assert result.coverage_assessment.confidence < 0.5  # ความมั่นใจต่ำ
             assert result.warnings, "Expected warnings when no passages are found"
             expected_warning_keys = {"insufficient_passages", "no_primary_passages"}
-            assert expected_warning_keys.intersection(set(result.warnings)), (
-                "Warnings should include insufficient passages information"
-            )
+            assert expected_warning_keys.intersection(
+                set(result.warnings)
+            ), "Warnings should include insufficient passages information"


### PR DESCRIPTION
## Summary
- format doctrine validator agent to collapse a multiline string per black style
- apply black formatting updates to script outline agent and the research retrieval tests

## Testing
- black --check .

------
https://chatgpt.com/codex/tasks/task_e_68d5f273efd883209cb61df096e865c3