### PR TITLE
Fix Iterable import for Python 3.12

### DIFF
--- a/src/agents/seo_metadata/agent.py
+++ b/src/agents/seo_metadata/agent.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Iterable
+from collections.abc import Iterable
 
 from automation_core.base_agent import BaseAgent
 
 from .model import (
     MetaInfo,
+    SelfCheck,
     SeoMetadataInput,
     SeoMetadataOutput,
-    SelfCheck,
 )
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- import `Iterable` from `collections.abc` instead of `typing` in the SEO metadata agent
- organize the import block after the change

## Testing
- poetry run ruff check

------
https://chatgpt.com/codex/tasks/task_e_68d6238abd9883208eb7e6dba11dd751