### PR TITLE
Fix Iterable import for SEO metadata agent

### DIFF
--- a/src/agents/seo_metadata/agent.py
+++ b/src/agents/seo_metadata/agent.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Iterable
+from collections.abc import Iterable
 
 from automation_core.base_agent import BaseAgent
 
 from .model import (
     MetaInfo,
+    SelfCheck,
     SeoMetadataInput,
     SeoMetadataOutput,
-    SelfCheck,
 )
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- update SeoMetadataAgent to import Iterable from collections.abc
- refresh import order in the SEO metadata agent module

## Testing
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68d6220b14e48320a970a67de8e7ddc0