### PR TITLE
Fix formatting for SEO metadata agent

### DIFF
--- a/src/agents/seo_metadata/agent.py
+++ b/src/agents/seo_metadata/agent.py
@@ -135,7 +135,7 @@ class SeoMetadataAgent(BaseAgent[SeoMetadataInput, SeoMetadataOutput]):
 
         if keyword and not base_title.startswith(keyword):
             if base_title.lower().startswith(keyword.lower()):
-                base_title = f"{keyword}{base_title[len(keyword):]}"
+                base_title = f"{keyword}{base_title[len(keyword) :]}"
             else:
                 base_title = f"{keyword} {base_title}".strip()
 


### PR DESCRIPTION
## Summary
- format `src/agents/seo_metadata/agent.py` to comply with the project formatter

## Testing
- `ruff format --check src/agents/seo_metadata/agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68d64a3c7ae08320b4bc0ac1a8ba2f1f