### PR TITLE
Refactor scheduling slot selection and constraints

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -9,10 +9,6 @@ from .localization_subtitle.model import (
 )
 from .research_retrieval.agent import ResearchRetrievalAgent
 from .research_retrieval.model import ResearchRetrievalInput, ResearchRetrievalOutput
-from .script_outline.agent import ScriptOutlineAgent
-from .script_outline.model import ScriptOutlineInput, ScriptOutlineOutput
-from .script_writer.agent import ScriptWriterAgent
-from .script_writer.model import ScriptWriterInput, ScriptWriterOutput
 from .scheduling_publishing.agent import SchedulingPublishingAgent
 from .scheduling_publishing.model import (
     AudienceAnalytics,
@@ -21,6 +17,10 @@ from .scheduling_publishing.model import (
     SchedulingInput,
     SchedulingOutput,
 )
+from .script_outline.agent import ScriptOutlineAgent
+from .script_outline.model import ScriptOutlineInput, ScriptOutlineOutput
+from .script_writer.agent import ScriptWriterAgent
+from .script_writer.model import ScriptWriterInput, ScriptWriterOutput
 from .seo_metadata.agent import SeoMetadataAgent
 from .seo_metadata.model import SeoMetadataInput, SeoMetadataOutput
 from .topic_prioritizer.agent import TopicPrioritizerAgent

--- a/src/agents/scheduling_publishing/utils.py
+++ b/src/agents/scheduling_publishing/utils.py
@@ -1,0 +1,14 @@
+"""Shared utilities for scheduling & publishing."""
+from __future__ import annotations
+
+from datetime import datetime
+
+__all__ = ["parse_iso_datetime"]
+
+
+def parse_iso_datetime(value: str) -> datetime:
+    """Parse ISO 8601 strings while supporting trailing ``Z`` shorthand."""
+
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value)

--- a/tests/test_scheduling_publishing_agent.py
+++ b/tests/test_scheduling_publishing_agent.py
@@ -194,3 +194,22 @@ def test_scheduling_agent_collision_and_overflow() -> None:
     assert result.meta.self_check.no_collision is False
     assert result.meta.self_check.no_overflow is False
     assert result.warnings  # warnings should include collision/overflow notes
+
+
+def test_agent_requires_anchor_for_base_week(basic_input: SchedulingInput) -> None:
+    agent = SchedulingPublishingAgent()
+
+    anchorless_input = basic_input.model_copy(
+        update={
+            "constraints": ScheduleConstraints(
+                max_videos_per_day=basic_input.constraints.max_videos_per_day,
+                max_longform_per_week=basic_input.constraints.max_longform_per_week,
+                max_shorts_per_week=basic_input.constraints.max_shorts_per_week,
+                avoid_duplicate_pillar_in_24hr=basic_input.constraints.avoid_duplicate_pillar_in_24hr,
+                forbidden_times=[],
+            )
+        }
+    )
+
+    with pytest.raises(ValueError):
+        agent.run(anchorless_input)


### PR DESCRIPTION
## Summary
- Refactor the scheduling agent to share slot-selection logic, enforce weekly capacity via optional content-type limits, and require an explicit planning anchor when no forbidden windows are supplied.
- Pre-compute forbidden intervals inside `ScheduleConstraints`, switch Optional annotations to the modern `| None` style, and centralize ISO datetime parsing in a shared utility.
- Add coverage ensuring plans without a `planning_start_date` or `forbidden_times` fail fast so schedules remain deterministic.

## Testing
- `pytest`
- `ruff check`


------
https://chatgpt.com/codex/tasks/task_e_68d6629592008320aa3a607ab3035640