### PR TITLE
Fix Ruff formatting in research retrieval tests

### DIFF
--- a/tests/test_research_retrieval_agent.py
+++ b/tests/test_research_retrieval_agent.py
@@ -362,6 +362,6 @@ class TestResearchRetrievalAgent:
             assert result.coverage_assessment.confidence < 0.5  # ความมั่นใจต่ำ
             assert result.warnings, "Expected warnings when no passages are found"
             expected_warning_keys = {"insufficient_passages", "no_primary_passages"}
-            assert expected_warning_keys.intersection(
-                set(result.warnings)
-            ), "Warnings should include insufficient passages information"
+            assert expected_warning_keys.intersection(set(result.warnings)), (
+                "Warnings should include insufficient passages information"
+            )


### PR DESCRIPTION
## Summary
- format `tests/test_research_retrieval_agent.py` with Ruff to satisfy style check

## Testing
- `ruff format --check .`


------
https://chatgpt.com/codex/tasks/task_e_68d6828c82388320963dace02f7ad057