### PR TITLE
Remove mid clip drop flag and align naming

### DIFF
--- a/docs/PROMPTS_OVERVIEW.md
+++ b/docs/PROMPTS_OVERVIEW.md
@@ -240,8 +240,7 @@ filled_prompt = prompt_template.format(
 
 **Flag Conditions**:
 - `early_drop`: retention drop ภายใน 120 วินาทีแรก
-- `mid_clip_drop`: drop point อยู่ช่วงกลางคลิป (≥120 วินาที)
-- `gradual_drop`: retention ลดลงอย่างต่อเนื่องและชัน
+- `gradual drop`: retention ลดลงอย่างต่อเนื่องและชัน
 - `low_ctr`: CTR ต่ำกว่า baseline หรือ goal
 - `low_comments`: คอมเมนต์ต่ำกว่าค่าเฉลี่ย baseline
 - `underperform`: ตัวชี้วัดรวมหลายมิติต่ำกว่า baseline อย่างมีนัยสำคัญ

--- a/prompts/analytics_retention_agent_v1.txt
+++ b/prompts/analytics_retention_agent_v1.txt
@@ -107,9 +107,7 @@
     "A/B test thumbnail กับแนว emotional face",
     "เพิ่ม CTA ให้คนคอมเมนต์ประสบการณ์"
   ],
-  "flags": [
-    "mid_clip_drop"
-  ],
+  "flags": [],
   "meta": {
     "baseline_id": "2025-09-avg",
     "goal_id": "2025-10-campaign1",
@@ -127,7 +125,7 @@
 2. all_compare_fields_present: views/ctr/avd/retention มี compare_to_baseline
 3. no_missing_data: ข้อมูลครบ
 4. ถ้าข้อมูลขาด/ผิด → ใส่ warnings[] ระบุข้อผิดพลาด
-5. flags: include “early_drop”, “mid_clip_drop”, “gradual_drop”, “low_ctr”, “low_comments”, “underperform” ตามเงื่อนไข
+5. flags: include “early_drop”, “gradual drop”, “low_ctr”, “low_comments”, “underperform” ตามเงื่อนไข
 
 [ERROR SCHEMA]
 {
@@ -229,9 +227,7 @@ Goal: {goal_json}
     "A/B test thumbnail กับแนว emotional face",
     "เพิ่ม CTA ให้คนคอมเมนต์ประสบการณ์"
   ],
-  "flags": [
-    "mid_clip_drop"
-  ],
+  "flags": [],
   "meta": {
     "baseline_id": "2025-09-avg",
     "goal_id": "2025-10-campaign1",


### PR DESCRIPTION
## Summary
- remove the mid_clip_drop flag rule and references from the analytics retention prompt
- align the example output and validation list to match the available flags
- update the prompts overview documentation to use the gradual drop spelling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6acaaa998832087a8aacac0dc8a3a