### PR TITLE
Align retention flag names

### DIFF
--- a/prompts/analytics_retention_agent_v1.txt
+++ b/prompts/analytics_retention_agent_v1.txt
@@ -125,7 +125,7 @@
 2. all_compare_fields_present: views/ctr/avd/retention มี compare_to_baseline
 3. no_missing_data: ข้อมูลครบ
 4. ถ้าข้อมูลขาด/ผิด → ใส่ warnings[] ระบุข้อผิดพลาด
-5. flags: include “early_drop”, “gradual drop”, “low_ctr”, “low_comments”, “underperform” ตามเงื่อนไข
+5. flags: include “early drop”, “gradual drop”, “low_ctr”, “low_comments”, “underperform” ตามเงื่อนไข
 
 [ERROR SCHEMA]
 {


### PR DESCRIPTION
## Summary
- update the validation rules for the analytics retention agent prompt to expect the "early drop" flag with a space so it matches the analytics instructions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6b3baed0483209216f6e9141a7ad6