### PR TITLE
Fix ErrorFlag agent style and typing

### DIFF
--- a/src/agents/error_flag/__init__.py
+++ b/src/agents/error_flag/__init__.py
@@ -4,9 +4,9 @@ from .agent import ErrorFlagAgent
 from .model import (
     AgentError,
     AgentLog,
+    CriticalItem,
     ErrorFlagInput,
     ErrorFlagOutput,
-    CriticalItem,
     WarningItem,
 )
 

--- a/src/agents/error_flag/agent.py
+++ b/src/agents/error_flag/agent.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections import Counter, defaultdict
-from typing import Dict, List, Tuple
 
 from automation_core.base_agent import BaseAgent
 
@@ -20,7 +19,7 @@ from .model import (
 # Message libraries for known flags/warnings
 # ---------------------------------------------------------------------------
 
-_FLAG_LIBRARY: Dict[str, Tuple[str, str]] = {
+_FLAG_LIBRARY: dict[str, tuple[str, str]] = {
     "mid_clip_drop": ("Retention ลดช่วงกลางคลิป", "ปรับ pacing, shorten ช่วงกลาง"),
     "low_comments": ("จำนวนคอมเมนต์ต่ำกว่าค่าเฉลี่ย", "เพิ่ม CTA กระตุ้นคอมเมนต์"),
     "underperform": (
@@ -38,7 +37,7 @@ _FLAG_LIBRARY: Dict[str, Tuple[str, str]] = {
     ),
 }
 
-_WARNING_LIBRARY: Dict[str, Tuple[str, str]] = {
+_WARNING_LIBRARY: dict[str, tuple[str, str]] = {
     "overflow_count > 0": (
         "มีวิดีโอรอ publish เกินโควต้าต่อวัน/สัปดาห์",
         "กระจาย schedule เพิ่มหรือเพิ่ม slot",
@@ -66,23 +65,23 @@ class ErrorFlagAgent(BaseAgent[ErrorFlagInput, ErrorFlagOutput]):
     def run(self, input_data: ErrorFlagInput) -> ErrorFlagOutput:
         """Aggregate logs and produce summary output."""
 
-        summary: List[str] = []
-        critical_items: List[CriticalItem] = []
-        warning_items: List[WarningItem] = []
-        info_items: List[str] = []
+        summary: list[str] = []
+        critical_items: list[CriticalItem] = []
+        warning_items: list[WarningItem] = []
+        info_items: list[str] = []
 
         error_counter: Counter[str] = Counter()
         flag_counter: Counter[str] = Counter()
         warning_counter: Counter[str] = Counter()
 
-        error_messages: Dict[str, str] = {}
-        flag_messages: Dict[str, str] = {}
-        warning_messages: Dict[str, str] = {}
+        error_messages: dict[str, str] = {}
+        flag_messages: dict[str, str] = {}
+        warning_messages: dict[str, str] = {}
 
         unique_agents = {log.agent for log in input_data.agent_logs}
 
         # Collect per-agent flags for summary reporting
-        flags_per_agent: Dict[str, List[str]] = defaultdict(list)
+        flags_per_agent: dict[str, list[str]] = defaultdict(list)
 
         for log in input_data.agent_logs:
             # ------------------------------------------------------------------
@@ -205,15 +204,15 @@ class ErrorFlagAgent(BaseAgent[ErrorFlagInput, ErrorFlagOutput]):
 
 def _build_root_cause_messages(
     error_counter: Counter[str],
-    error_messages: Dict[str, str],
+    error_messages: dict[str, str],
     flag_counter: Counter[str],
-    flag_messages: Dict[str, str],
+    flag_messages: dict[str, str],
     warning_counter: Counter[str],
-    warning_messages: Dict[str, str],
-) -> List[str]:
+    warning_messages: dict[str, str],
+) -> list[str]:
     """สร้างข้อความ root cause จากสถิติต่าง ๆ."""
 
-    messages: List[str] = []
+    messages: list[str] = []
 
     for code, count in error_counter.items():
         if count >= 2:

--- a/src/agents/error_flag/model.py
+++ b/src/agents/error_flag/model.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import BaseModel, Field, model_validator
 
 
@@ -12,7 +10,7 @@ class AgentError(BaseModel):
 
     code: str = Field(..., description="รหัส error จาก agent")
     message: str = Field(..., description="ข้อความอธิบาย error")
-    suggested_fix: Optional[str] = Field(
+    suggested_fix: str | None = Field(
         default=None,
         description="คำแนะนำการแก้ไขจาก agent ต้นทาง",
         alias="suggested_fix",
@@ -23,11 +21,11 @@ class AgentLog(BaseModel):
     """ข้อมูล log ต่อ agent ที่ Error/Flag agent ใช้เป็น input."""
 
     agent: str = Field(..., description="ชื่อ agent ที่ส่ง log")
-    error: Optional[AgentError] = Field(
+    error: AgentError | None = Field(
         default=None, description="ข้อมูล error ถ้ามี"
     )
-    flags: List[str] = Field(default_factory=list, description="รายการ flag")
-    warnings: List[str] = Field(
+    flags: list[str] = Field(default_factory=list, description="รายการ flag")
+    warnings: list[str] = Field(
         default_factory=list, description="รายการ warning จาก agent"
     )
 
@@ -35,7 +33,7 @@ class AgentLog(BaseModel):
 class ErrorFlagInput(BaseModel):
     """Input schema สำหรับ ErrorFlagAgent."""
 
-    agent_logs: List[AgentLog] = Field(
+    agent_logs: list[AgentLog] = Field(
         default_factory=list, description="ลิสต์ log จาก agent ทั้งหมด"
     )
 
@@ -46,20 +44,20 @@ class CriticalItem(BaseModel):
     agent: str
     error_code: str
     message: str
-    suggested_action: Optional[str] = None
+    suggested_action: str | None = None
 
 
 class WarningItem(BaseModel):
     """โครงสร้างข้อมูลสำหรับ Warning severity."""
 
     agent: str
-    flag: Optional[str] = None
-    warning: Optional[str] = None
+    flag: str | None = None
+    warning: str | None = None
     message: str
-    suggested_action: Optional[str] = None
+    suggested_action: str | None = None
 
     @model_validator(mode="after")
-    def _ensure_flag_or_warning(self) -> "WarningItem":
+    def _ensure_flag_or_warning(self) -> WarningItem:
         if not self.flag and not self.warning:
             raise ValueError("ต้องมี flag หรือ warning อย่างน้อยหนึ่งตัว")
         return self
@@ -85,11 +83,11 @@ class MetaSection(BaseModel):
 class ErrorFlagOutput(BaseModel):
     """Output schema ตามที่ workflow ต้องการ."""
 
-    summary: List[str]
-    critical: List[CriticalItem]
-    warning: List[WarningItem]
-    info: List[str]
-    root_cause: List[str]
+    summary: list[str]
+    critical: list[CriticalItem]
+    warning: list[WarningItem]
+    info: list[str]
+    root_cause: list[str]
     meta: MetaSection
 
 


### PR DESCRIPTION
## Summary
- update the ErrorFlag models to use modern builtin generics and PEP 604 union syntax
- refresh the package exports and agent helpers to align with Ruff formatting fixes

## Testing
- ruff check src/agents/error_flag

------
https://chatgpt.com/codex/tasks/task_e_68d7295c42248320bf4641b573eb17a5