### PR TITLE
Refactor data sync schema loading and validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,12 +54,15 @@ Documentation = "https://natbkgift.github.io/dhamma-channel-automation"
 dhamma-automation = "cli.main:app"
 
 [tool.setuptools.packages.find]
-where = ["."]
-include = ["src*", "cli*", "automation_core*", "agents*"]
+where = ["src", "."]
+include = ["automation_core*", "agents*", "cli*"]
 
 [tool.setuptools.package-dir]
-"automation_core" = "src/automation_core"
-"agents" = "src/agents"
+"" = "src"
+"cli" = "cli"
+
+[tool.setuptools.package-data]
+"agents.data_sync" = ["schema_registry.json"]
 
 [tool.ruff]
 target-version = "py311"

--- a/src/agents/data_sync/schema_registry.json
+++ b/src/agents/data_sync/schema_registry.json
@@ -1,0 +1,15 @@
+{
+  "v2.1": [
+    "video_id",
+    "title",
+    "views",
+    "ctr_pct",
+    "retention_pct"
+  ],
+  "v2.0": [
+    "video_id",
+    "title",
+    "views",
+    "ctr_pct"
+  ]
+}


### PR DESCRIPTION
## Summary
- load the data sync schema registry from packaged JSON with optional overrides
- validate duplicate request fields alongside missing/extra detection and log results
- configure setuptools to expose src packages and include the schema registry while cleaning tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7cd02b9188320bbad58ee3d62f11d