### PR TITLE
Fix data sync agent logging and schema checks

### DIFF
--- a/prompts/data_sync_agent_v1.txt
+++ b/prompts/data_sync_agent_v1.txt
@@ -1,0 +1,155 @@
+# Data Sync Agent Prompt (v1)
+
+[ROLE / SYSTEM]
+คุณคือ “Data Sync Agent” สำหรับระบบอัตโนมัติช่อง YouTube ธรรมะดีดี มีหน้าที่:
+- ประสานงาน copy, sync, migrate, update, หรือ merge ข้อมูลระหว่างระบบภายใน (เช่น agent data, analytics, content, logs) กับภายนอก (Google Drive, BigQuery, S3, Airtable, GitHub, ฯลฯ)
+- ตรวจสอบ schema, version, conflict, duplication, missing/extra field
+- แจ้งเตือนหรือแก้ไขปัญหา sync (error/warning/log)
+- สร้าง data_sync_payload (JSON) สำหรับ operator หรือระบบ downstream
+
+[OBJECTIVE]
+รับ data_sync_request (source, target, data, sync_type, rule) → วิเคราะห์, validate, สร้าง data_sync_payload (JSON) ให้ถูกต้อง, สรุป log, แจ้งเตือน/แนะนำ action ถ้ามีปัญหา
+
+[INPUT EXPECTED – JSON FIELDS]
+{
+  "data_sync_request": {
+    "source_system": "YouTube Analytics",
+    "target_system": "Google Drive",
+    "sync_type": "copy",
+    "data": {
+      "file_name": "analytics_2025-09-27.csv",
+      "schema_version": "v2.1",
+      "fields": ["video_id", "title", "views", "ctr_pct", "retention_pct"],
+      "row_count": 134
+    },
+    "rule": {
+      "overwrite_if_exists": true,
+      "validate_schema": true
+    }
+  }
+}
+
+[DATA SYNC RULES]
+- ตรวจสอบ schema version, field completeness, field mapping (source-target)
+- หาก overwrite_if_exists=true ให้ flag หาก file target มีอยู่
+- validate_schema=true → เช็ค field ตรง schema, แจ้งเตือน missing/extra field
+- หาก row_count=0 หรือ field ขาด → warning/error
+- status: ready | pending | warning | error | merged
+- data_sync_log: event, timestamp, status, message (ถ้ามี)
+- suggestions: แนะนำ action ถ้ามีปัญหา schema, conflict, version, row_count
+- warnings: ถ้าพบปัญหา non-blocking
+- errors: ถ้าพบปัญหา blocking (schema mismatch, file not found, auth fail)
+- ถ้าสำเร็จ → status = ready/merged, log mapping success, no suggestions/warnings/errors
+
+[OUTPUT SCHEMA (STRICT JSON)]
+{
+  "data_sync_payload": {
+    "source_system": "YouTube Analytics",
+    "target_system": "Google Drive",
+    "file_name": "analytics_2025-09-27.csv",
+    "schema_version": "v2.1",
+    "field_mapping": ["video_id", "title", "views", "ctr_pct", "retention_pct"],
+    "row_count": 134,
+    "sync_type": "copy",
+    "rule": {
+      "overwrite_if_exists": true,
+      "validate_schema": true
+    },
+    "status": "ready"
+  },
+  "data_sync_log": [
+    {
+      "timestamp": "2025-09-27T09:59:03Z",
+      "event": "schema_validated",
+      "status": "success",
+      "message": "field mapping ตรง schema v2.1"
+    },
+    {
+      "timestamp": "2025-09-27T09:59:04Z",
+      "event": "file_copied",
+      "status": "success",
+      "message": "copy analytics_2025-09-27.csv ไป Google Drive สำเร็จ"
+    }
+  ],
+  "suggestions": [],
+  "warnings": [],
+  "errors": []
+}
+
+[VALIDATION & SELF-CHECK RULES]
+1. ถ้า field ขาด/extra, schema mismatch, row_count=0 → warning หรือ error
+2. data_sync_log ต้องมี event ทุกขั้นตอนสำคัญ
+3. status = error ถ้า blocking (schema mismatch, missing file, auth fail)
+4. suggestions/warnings/errors ต้องถูกต้องตาม logic
+5. ถ้าสำเร็จ → status ready/merged, ไม่มี suggestions/warnings/errors
+
+[ERROR SCHEMA]
+{
+  "error": {
+    "code": "MISSING_DATA | SCHEMA_MISMATCH | SYNC_ERROR",
+    "message": "รายละเอียด",
+    "suggested_fix": "คำแนะนำ"
+  }
+}
+
+[USER RUNTIME TEMPLATE]
+ดำเนินการ data sync สำหรับ request นี้ (JSON):
+DataSyncRequest: {{data_sync_request_json}}
+
+ส่งออก JSON ตาม Output Schema เท่านั้น ห้ามมีข้อความอื่นนอก JSON
+
+[ตัวอย่าง input]
+{
+  "data_sync_request": {
+    "source_system": "YouTube Analytics",
+    "target_system": "Google Drive",
+    "sync_type": "copy",
+    "data": {
+      "file_name": "analytics_2025-09-27.csv",
+      "schema_version": "v2.1",
+      "fields": ["video_id", "title", "views", "ctr_pct", "retention_pct"],
+      "row_count": 134
+    },
+    "rule": {
+      "overwrite_if_exists": true,
+      "validate_schema": true
+    }
+  }
+}
+
+[ตัวอย่าง output]
+{
+  "data_sync_payload": {
+    "source_system": "YouTube Analytics",
+    "target_system": "Google Drive",
+    "file_name": "analytics_2025-09-27.csv",
+    "schema_version": "v2.1",
+    "field_mapping": ["video_id", "title", "views", "ctr_pct", "retention_pct"],
+    "row_count": 134,
+    "sync_type": "copy",
+    "rule": {
+      "overwrite_if_exists": true,
+      "validate_schema": true
+    },
+    "status": "ready"
+  },
+  "data_sync_log": [
+    {
+      "timestamp": "2025-09-27T09:59:03Z",
+      "event": "schema_validated",
+      "status": "success",
+      "message": "field mapping ตรง schema v2.1"
+    },
+    {
+      "timestamp": "2025-09-27T09:59:04Z",
+      "event": "file_copied",
+      "status": "success",
+      "message": "copy analytics_2025-09-27.csv ไป Google Drive สำเร็จ"
+    }
+  ],
+  "suggestions": [],
+  "warnings": [],
+  "errors": []
+}
+
+[END OF PROMPT]

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,5 +1,14 @@
 """agents - โมดูลรวม AI Agents ทั้งหมด"""
 
+from .data_sync import (
+    DataSyncAgent,
+    DataSyncLogEntry,
+    DataSyncPayload,
+    DataSyncRequest,
+    DataSyncResponse,
+    SyncData,
+    SyncRule,
+)
 from .error_flag import (
     AgentError as ErrorFlagAgentError,
 )
@@ -75,6 +84,13 @@ __all__ = [
     "LocalizationSubtitleOutput",
     "LocalizationSubtitleMeta",
     "SubtitleSegment",
+    "DataSyncAgent",
+    "DataSyncRequest",
+    "DataSyncResponse",
+    "DataSyncPayload",
+    "DataSyncLogEntry",
+    "SyncData",
+    "SyncRule",
     "ErrorFlagAgent",
     "ErrorFlagInput",
     "ErrorFlagOutput",

--- a/src/agents/data_sync/__init__.py
+++ b/src/agents/data_sync/__init__.py
@@ -1,0 +1,21 @@
+"""DataSyncAgent - Agent สำหรับจัดการงานซิงก์ข้อมูล"""
+
+from .agent import DataSyncAgent
+from .model import (
+    DataSyncLogEntry,
+    DataSyncPayload,
+    DataSyncRequest,
+    DataSyncResponse,
+    SyncData,
+    SyncRule,
+)
+
+__all__ = [
+    "DataSyncAgent",
+    "DataSyncRequest",
+    "DataSyncResponse",
+    "DataSyncPayload",
+    "DataSyncLogEntry",
+    "SyncData",
+    "SyncRule",
+]

--- a/src/agents/data_sync/agent.py
+++ b/src/agents/data_sync/agent.py
@@ -1,0 +1,177 @@
+"""DataSyncAgent - จัดการตรวจสอบและเตรียม payload สำหรับงานซิงก์ข้อมูล"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from automation_core.base_agent import BaseAgent
+
+from .model import (
+    DataSyncLogEntry,
+    DataSyncPayload,
+    DataSyncRequest,
+    DataSyncResponse,
+)
+
+
+class DataSyncAgent(BaseAgent[DataSyncRequest, DataSyncResponse]):
+    """Agent สำหรับประมวลผล data_sync_request และสร้าง payload พร้อม log"""
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="DataSyncAgent",
+            version="1.0.0",
+            description="ตรวจสอบ schema และเตรียม payload สำหรับงานซิงก์ข้อมูล",
+        )
+
+        # registry ของ schema เวอร์ชันต่างๆ และฟิลด์ที่คาดหวัง
+        self.schema_registry: dict[str, list[str]] = {
+            "v2.1": [
+                "video_id",
+                "title",
+                "views",
+                "ctr_pct",
+                "retention_pct",
+            ],
+            "v2.0": [
+                "video_id",
+                "title",
+                "views",
+                "ctr_pct",
+            ],
+        }
+
+    def run(self, input_data: DataSyncRequest) -> DataSyncResponse:
+        logs: list[DataSyncLogEntry] = []
+        warnings: list[str] = []
+        errors: list[str] = []
+        suggestions: list[str] = []
+
+        expected_fields = self.schema_registry.get(input_data.data.schema_version)
+
+        # 1. ตรวจสอบ schema
+        if input_data.rule.validate_schema:
+            if expected_fields is None:
+                errors.append(
+                    f"ไม่รู้จัก schema_version '{input_data.data.schema_version}'"
+                )
+                logs.append(
+                    DataSyncLogEntry(
+                        timestamp=datetime.now(UTC),
+                        event="schema_validated",
+                        status="failed",
+                        message=(
+                            f"schema_version {input_data.data.schema_version} ไม่อยู่ใน registry"
+                        ),
+                    )
+                )
+                suggestions.append("อัปเดต schema registry หรือใช้ schema_version ที่รองรับ")
+            else:
+                expected_set = set(expected_fields)
+                actual_set = set(input_data.data.fields)
+                missing_fields = sorted(expected_set - actual_set)
+                extra_fields = sorted(actual_set - expected_set)
+
+                if missing_fields:
+                    errors.append("พบฟิลด์ขาดหาย: " + ", ".join(missing_fields))
+                    suggestions.append("เติมข้อมูลฟิลด์ที่จำเป็นให้ตรงกับ schema ก่อนทำการซิงก์")
+                    schema_status = "failed"
+                    schema_message = "ฟิลด์ไม่ครบตาม schema: " + ", ".join(missing_fields)
+                else:
+                    schema_status = "success"
+                    schema_message = (
+                        f"field mapping ตรง schema {input_data.data.schema_version}"
+                    )
+
+                logs.append(
+                    DataSyncLogEntry(
+                        timestamp=datetime.now(UTC),
+                        event="schema_validated",
+                        status=schema_status,
+                        message=schema_message,
+                    )
+                )
+
+                if extra_fields:
+                    warnings.append("พบฟิลด์เกินจาก schema: " + ", ".join(extra_fields))
+                    suggestions.append(
+                        "พิจารณาตรวจสอบฟิลด์ที่เกินก่อนการซิงก์หรืออัปเดต schema หากจำเป็น"
+                    )
+
+        # 2. ตรวจสอบ row_count
+        if input_data.data.row_count <= 0:
+            errors.append("row_count ต้องมากกว่า 0")
+            logs.append(
+                DataSyncLogEntry(
+                    timestamp=datetime.now(UTC),
+                    event="row_count_checked",
+                    status="failed",
+                    message="จำนวนแถวเป็น 0 หรือค่าติดลบ",
+                )
+            )
+            suggestions.append("ตรวจสอบขั้นตอนดึงข้อมูลหรือ filter ที่อาจทำให้ไม่มีข้อมูล")
+        else:
+            logs.append(
+                DataSyncLogEntry(
+                    timestamp=datetime.now(UTC),
+                    event="row_count_checked",
+                    status="success",
+                    message=f"row_count = {input_data.data.row_count}",
+                )
+            )
+
+        # 3. ตรวจสอบ overwrite flag
+        if input_data.rule.overwrite_if_exists:
+            logs.append(
+                DataSyncLogEntry(
+                    timestamp=datetime.now(UTC),
+                    event="overwrite_flag",
+                    status="pending",
+                    message="ตั้งค่า overwrite_if_exists = true (ตรวจสอบไฟล์ปลายทางก่อนคัดลอก)",
+                )
+            )
+
+        # 4. ตัดสินใจสถานะและ log ผลการคัดลอก
+        if errors:
+            final_status = "error"
+            logs.append(
+                DataSyncLogEntry(
+                    timestamp=datetime.now(UTC),
+                    event="sync_aborted",
+                    status="failed",
+                    message="หยุดการซิงก์เนื่องจากพบข้อผิดพลาด",
+                )
+            )
+        else:
+            final_status = "warning" if warnings else "ready"
+            logs.append(
+                DataSyncLogEntry(
+                    timestamp=datetime.now(UTC),
+                    event="payload_ready",
+                    status="warning" if warnings else "success",
+                    message=(
+                        "payload พร้อมสำหรับการซิงก์"
+                        + (" พร้อมคำเตือน." if warnings else ".")
+                    ),
+                )
+            )
+
+        payload = DataSyncPayload(
+            source_system=input_data.source_system,
+            target_system=input_data.target_system,
+            file_name=input_data.data.file_name,
+            schema_version=input_data.data.schema_version,
+            field_mapping=input_data.data.fields,
+            row_count=input_data.data.row_count,
+            sync_type=input_data.sync_type,
+            rule=input_data.rule,
+            status=final_status,
+        )
+
+        return DataSyncResponse(
+            data_sync_payload=payload,
+            data_sync_log=logs,
+            suggestions=suggestions,
+            warnings=warnings,
+            errors=errors,
+        )

--- a/src/agents/data_sync/model.py
+++ b/src/agents/data_sync/model.py
@@ -1,0 +1,73 @@
+"""โมเดลข้อมูลสำหรับ DataSyncAgent"""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field, validator
+
+
+class SyncRule(BaseModel):
+    """กฎการซิงก์ข้อมูล"""
+
+    overwrite_if_exists: bool = Field(
+        False, description="ถ้าจริงให้ overwrite ไฟล์ที่มีอยู่ในเป้าหมาย"
+    )
+    validate_schema: bool = Field(True, description="ตรวจสอบ schema ของข้อมูลก่อนซิงก์")
+
+
+class SyncData(BaseModel):
+    """รายละเอียดข้อมูลที่ต้องซิงก์"""
+
+    file_name: str = Field(..., description="ชื่อไฟล์ที่จะซิงก์")
+    schema_version: str = Field(..., description="เวอร์ชัน schema ของข้อมูล")
+    fields: list[str] = Field(..., description="รายชื่อฟิลด์ในข้อมูล")
+    row_count: int = Field(..., ge=0, description="จำนวนแถวของข้อมูล")
+
+    @validator("fields")
+    def validate_fields_not_empty(cls, value: list[str]) -> list[str]:
+        if not value:
+            raise ValueError("fields ต้องมีอย่างน้อย 1 รายการ")
+        return value
+
+
+class DataSyncRequest(BaseModel):
+    """คำขอสำหรับ DataSyncAgent"""
+
+    source_system: str
+    target_system: str
+    sync_type: Literal["copy", "sync", "migrate", "update", "merge"]
+    data: SyncData
+    rule: SyncRule
+
+
+class DataSyncLogEntry(BaseModel):
+    """รายการ log ของกระบวนการซิงก์"""
+
+    timestamp: datetime
+    event: str
+    status: Literal["success", "warning", "failed", "pending"]
+    message: str
+
+
+class DataSyncPayload(BaseModel):
+    """ข้อมูล payload สำหรับการซิงก์"""
+
+    source_system: str
+    target_system: str
+    file_name: str
+    schema_version: str
+    field_mapping: list[str]
+    row_count: int
+    sync_type: str
+    rule: SyncRule
+    status: Literal["ready", "pending", "warning", "error", "merged"]
+
+
+class DataSyncResponse(BaseModel):
+    """ผลลัพธ์ของ DataSyncAgent"""
+
+    data_sync_payload: DataSyncPayload
+    data_sync_log: list[DataSyncLogEntry]
+    suggestions: list[str]
+    warnings: list[str]
+    errors: list[str]

--- a/tests/test_data_sync_agent.py
+++ b/tests/test_data_sync_agent.py
@@ -1,0 +1,146 @@
+"""Unit tests สำหรับ DataSyncAgent"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from agents.data_sync import DataSyncAgent, DataSyncRequest, SyncData, SyncRule
+
+
+def build_request(**overrides) -> DataSyncRequest:
+    """สร้าง DataSyncRequest สำหรับใช้งานในเทสต์"""
+
+    base = {
+        "source_system": "YouTube Analytics",
+        "target_system": "Google Drive",
+        "sync_type": "copy",
+        "data": SyncData(
+            file_name="analytics_2025-09-27.csv",
+            schema_version="v2.1",
+            fields=["video_id", "title", "views", "ctr_pct", "retention_pct"],
+            row_count=134,
+        ),
+        "rule": SyncRule(overwrite_if_exists=True, validate_schema=True),
+    }
+    base.update(overrides)
+    return DataSyncRequest(**base)
+
+
+def test_data_sync_agent_success():
+    agent = DataSyncAgent()
+    request = build_request()
+
+    response = agent.run(request)
+
+    assert response.data_sync_payload.status == "ready"
+    assert response.data_sync_payload.field_mapping == request.data.fields
+    assert response.errors == []
+    assert response.warnings == []
+    assert response.suggestions == []
+
+    events = [log.event for log in response.data_sync_log]
+    assert events[0] == "schema_validated"
+    assert events[-1] == "payload_ready"
+    assert response.data_sync_log[0].status == "success"
+    assert response.data_sync_log[-1].status == "success"
+
+
+def test_data_sync_agent_missing_fields_error():
+    agent = DataSyncAgent()
+    request = build_request(
+        data=SyncData(
+            file_name="analytics_2025-09-27.csv",
+            schema_version="v2.1",
+            fields=["video_id", "title", "views"],
+            row_count=50,
+        )
+    )
+
+    response = agent.run(request)
+
+    assert response.data_sync_payload.status == "error"
+    assert response.errors, "ควรมี error เมื่อฟิลด์ขาด"
+    assert any("ฟิลด์" in error for error in response.errors)
+    assert any(log.status == "failed" for log in response.data_sync_log)
+
+
+def test_data_sync_agent_extra_fields_warning():
+    agent = DataSyncAgent()
+    request = build_request(
+        data=SyncData(
+            file_name="analytics_extra.csv",
+            schema_version="v2.1",
+            fields=[
+                "video_id",
+                "title",
+                "views",
+                "ctr_pct",
+                "retention_pct",
+                "watch_time",
+            ],
+            row_count=200,
+        )
+    )
+
+    response = agent.run(request)
+
+    assert response.data_sync_payload.status == "warning"
+    assert response.errors == []
+    assert response.warnings
+    assert any("ฟิลด์เกิน" in warning for warning in response.warnings)
+    assert response.data_sync_log[-1].status == "warning"
+
+
+def test_data_sync_agent_unknown_schema_error():
+    agent = DataSyncAgent()
+    request = build_request(
+        data=SyncData(
+            file_name="analytics_future.csv",
+            schema_version="v3.0",
+            fields=["video_id", "title", "views"],
+            row_count=10,
+        )
+    )
+
+    response = agent.run(request)
+
+    assert response.data_sync_payload.status == "error"
+    assert any("schema_version" in error for error in response.errors)
+    assert response.data_sync_log[0].status == "failed"
+
+
+def test_data_sync_agent_row_count_zero_error():
+    agent = DataSyncAgent()
+    request = build_request(
+        data=SyncData(
+            file_name="analytics_empty.csv",
+            schema_version="v2.1",
+            fields=["video_id", "title", "views", "ctr_pct", "retention_pct"],
+            row_count=0,
+        )
+    )
+
+    response = agent.run(request)
+
+    assert response.data_sync_payload.status == "error"
+    assert any("row_count" in error for error in response.errors)
+    assert any(
+        log.event == "row_count_checked" and log.status == "failed"
+        for log in response.data_sync_log
+    )
+
+
+@pytest.mark.parametrize(
+    "sync_type",
+    ["copy", "sync", "migrate", "update", "merge"],
+)
+def test_data_sync_agent_supports_multiple_sync_types(sync_type: str):
+    agent = DataSyncAgent()
+    request = build_request(sync_type=sync_type)
+
+    response = agent.run(request)
+
+    assert response.data_sync_payload.sync_type == sync_type


### PR DESCRIPTION
## Summary
- add a dedicated DataSync agent with schema registry validation, logging, and payload assembly
- capture the Data Sync operator prompt alongside new Pydantic models for requests, payloads, and responses
- cover success, warning, and error scenarios plus supported sync types with unit tests
- update the agent to emit per-event timestamps, report payload readiness, and rely on set-based schema field comparisons
- format the DataSync agent implementation and models to satisfy Ruff formatting checks

## Testing
- ruff check .
- ruff format --check .
- pytest tests/test_data_sync_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68d7b55744e88320be0541f2a39d7d3c