### PR TITLE
docs: add extended dhamma workflow overview

### DIFF
--- a/docs/DHAMMA_WORKFLOW.md
+++ b/docs/DHAMMA_WORKFLOW.md
@@ -1,0 +1,126 @@
+# 🧩 สรุป Chain/Flow ระบบ Automation "ธรรมะดีดี" (DhammaDD AI Workflow)
+
+> เอกสารฉบับนี้สรุป workflow หลักของระบบอัตโนมัติ "ธรรมะดีดี" พร้อมแนวทางขยายต่อยอดสำหรับทีมพัฒนา เพื่อใช้เป็นแผนแม่บทในการบริหารจัดการ AI Agents, Automation Chain และการวิเคราะห์ผลลัพธ์แบบ End-to-End
+
+## 1. Content & Production Chain (Core)
+การผลิตคอนเทนต์หลักสำหรับช่องธรรมะดีดีประกอบด้วยลำดับขั้นตอนดังนี้
+
+1. **Trend Scout Agent** – ค้นหาเทรนด์หรือคำถามด้านธรรมะที่กำลังได้รับความสนใจ
+2. **Topic Prioritizer Agent** – จัดลำดับความสำคัญหัวข้อที่ควรผลิตก่อนเพื่อให้เหมาะกับเป้าหมายของช่อง
+3. **Research Retrieval Agent** – ดึงข้อมูล อ้างอิงพระสูตร หรือหลักฐานสนับสนุนที่น่าเชื่อถือ
+4. **Script Outline Agent** – วางโครงสคริปต์และจุดสำคัญที่จะเล่า
+5. **Script Writer Agent** – เขียนสคริปต์ฉบับเต็มให้ครบถ้วนและเข้าใจง่าย
+6. **Doctrine Validator Agent** – ตรวจสอบความถูกต้องของเนื้อหาธรรมะและความเหมาะสมเชิงหลักธรรม
+7. **Localization & Subtitle Agent** – จัดทำซับไตเติลหรือปรับภาษาสำหรับหลายภาษา/สำเนียง
+8. **Voiceover Agent** – สร้างเสียงบรรยายประกอบวิดีโอ
+9. **Visual Asset Agent** – สร้างภาพประกอบหรือ visual materials ที่สอดคล้องกับสคริปต์
+10. **Thumbnail Generator Agent** – ออกแบบภาพหน้าปก (thumbnail) เพื่อเพิ่ม CTR
+11. **SEO & Metadata Agent** – สร้างชื่อเรื่อง คำอธิบาย แท็ก และ metadata เพื่อให้ค้นหาเจอง่าย
+12. **Scheduling & Publishing Agent** – ตั้งเวลาและเผยแพร่คอนเทนต์บนแพลตฟอร์มหลัก
+
+## 2. Analytics & Optimization Loop
+เมื่อคอนเทนต์ถูกเผยแพร่ ระบบวิเคราะห์และเพิ่มประสิทธิภาพจะทำงานวนลูปต่อเนื่อง
+
+- **Analytics & Retention Agent** – รวบรวมสถิติ เช่น Retention, CTR, Engagement
+- **Experiment Orchestrator Agent** – ออกแบบ/ติดตามผลการทดสอบ A/B เช่น thumbnail, title
+- **Growth Forecast Agent** – พยากรณ์ยอดวิวและรายได้ในอนาคต
+- **Feedback Loop Agent** – วิเคราะห์ข้อมูลและเสนอ Action Plan เพื่อปรับปรุงคอนเทนต์ถัดไป
+
+## 3. Oversight & Automation Chain
+ชั้นดูแลระบบและงานเบื้องหลังเพื่อให้ Automation ทำงานได้อย่างปลอดภัยและมีเสถียรภาพ
+
+- **Dashboard Agent** – สรุปภาพรวมผลการทำงานและสถานะระบบแบบเรียลไทม์
+- **Error/Flag Agent** – ตรวจจับข้อผิดพลาดหรือ Warning เพื่อแจ้งทีมทันที
+- **Legal/Compliance Agent** – ตรวจสอบลิขสิทธิ์และข้อกำกับทางกฎหมาย
+- **Notification Agent** – ส่งการแจ้งเตือนไปยังผู้รับผิดชอบตามช่องทางที่กำหนด
+- **Integration Agent** – เชื่อมระบบภายนอก เช่น API, Cloud Functions หรือฐานข้อมูลอื่น
+- **Monitoring Agent** – เฝ้าระวัง Uptime และ Performance ของแต่ละ Agent
+- **Data Sync Agent** – ซิงก์ข้อมูลระหว่างระบบหรือสำรองตามนโยบายข้อมูล
+
+## 4. Prompt Pack, Agent Template, Diagram
+- **Prompt Pack / Workflow Diagram** – ศูนย์รวม Prompt, Schema และ Flow สำหรับทีมใช้ร่วมกัน
+- **Agent Template** – พิมพ์เขียวสำหรับสร้าง Agent ใหม่ให้มาตรฐานตรงกัน (โครงสร้างไฟล์, ตัวแปร, Logging ฯลฯ)
+
+## 5. Optional / Advanced / Expandable Agents
+> สามารถเพิ่มได้ตาม Use Case หรือเมื่อระบบต้องการ Scale มากขึ้น
+
+### A. Multi-Channel / Multi-Format
+- **Multi-Channel Publish Agent** – กระจายคอนเทนต์ไป TikTok, Facebook, Podcast ฯลฯ
+- **Format Conversion Agent** – ปรับคอนเทนต์ให้เหมาะกับแต่ละแพลตฟอร์ม (Vertical, Podcast, Blog, Infographic)
+
+### B. Personalization & Advanced Analytics
+- **Personalization Agent** – แนะนำหัวข้อหรือคอนเทนต์เฉพาะบุคคล
+- **User Feedback Collector Agent** – ดึง Feedback จากคอมเมนต์ โซเชียล หรือ Watcher กลุ่มต่าง ๆ
+- **Community Insight Agent** – วิเคราะห์แนวโน้ม คำถาม และความสนใจของชุมชน
+
+### C. Security, Cost, Resource
+- **Security Agent** – ตรวจจับข้อมูลรั่วไหล บันทึกการเข้าถึง หรือความผิดปกติของสิทธิ์
+- **Cost Optimization Agent** – วิเคราะห์การใช้ทรัพยากร พร้อมแจ้งเตือนค่าใช้จ่าย
+- **Backup / Archive Agent** – สำรองไฟล์และข้อมูลอัตโนมัติ
+
+### D. ML / AI Pipeline
+- **Training Data Agent** – คัดเลือกและจัดเตรียมข้อมูลสำหรับการฝึกโมเดล
+- **Auto-Labeling Agent** – สร้างฉลากหรือ Annotation อัตโนมัติ
+
+### E. Automation Enhancer
+- **Dynamic Orchestrator Agent** – ปรับกลยุทธ์หรือเรียงลำดับ Workflow ตามบริบท/สถานการณ์
+- **Auto-Scheduling Agent** – เลือกช่วงเวลาโพสต์ที่เหมาะสมที่สุดโดยใช้ข้อมูลเชิงคาดการณ์
+- **Auto-Scaling Agent** – เพิ่ม/ลดจำนวน Agent โดยอัตโนมัติเมื่อโหลดสูง
+
+### F. Reporting & BI
+- **Advanced BI Agent** – สร้างรายงาน, Dashboard หรือไฟล์ PDF สำหรับผู้บริหาร
+
+## 6. Flow Diagram (Text Version พร้อมจุดขยาย)
+```
+[Trend Scout]
+   ↓
+[Topic Prioritizer]
+   ↓
+[Research Retrieval] → [Doctrine Validator]
+   ↓
+[Script Outline]
+   ↓
+[Script Writer]
+   ↓
+[Localization & Subtitle] → [Voiceover]
+   ↓
+[Visual Asset] → [Thumbnail Generator]
+   ↓
+[SEO & Metadata]
+   ↓
+[Scheduling & Publishing]
+   ↓
+────────────────────────────────────────────────────
+│           │                │           │        │
+↓           ↓                ↓           ↓        ↓
+[Analytics & Retention]   [Experiment Orchestrator]   [Legal/Compliance]   [User Feedback Collector]
+   │           │                │                     │
+   └─────→[Growth Forecast]     │                     ↓
+   │           │                │                [Community Insight]
+   └─────→[Feedback Loop]       │
+────────────────────────────────────────────────────
+          ↓
+      [Dashboard]
+          │
+    ┌────────────┬─────────────┬─────────────┬────────────┬───────────────┐
+    │            │             │             │            │               │
+[Error/Flag] [Notification] [Integration] [Monitoring] [Data Sync] [Backup]
+                                          │
+                                   [Security/Cost]
+────────────────────────────────────────────────────
+          ↓
+      [Multi-Channel Publish] ← [Format Conversion]
+          │
+   [Personalization] [BI/Reporting]
+```
+
+## 7. จุดเด่นของการออกแบบแบบ "ขยายต่อยอด"
+- เริ่มจากโครงหลัก แล้วค่อยเพิ่ม Agent ตามความพร้อมหรือความจำเป็น
+- ปรับแต่งเพิ่มความอัจฉริยะและความปลอดภัยได้โดยไม่รบกวน Flow หลัก
+- รองรับการกระจายคอนเทนต์หลายแพลตฟอร์มและรูปแบบ
+- ขยายได้ทั้งด้าน Content, Compliance, Infrastructure, Data และ ML/AI Pipeline
+
+## 8. หมายเหตุสำคัญ
+- ไม่จำเป็นต้องเปิดใช้ทุก Agent ตั้งแต่เริ่มต้น ค่อย ๆ เพิ่มตามการเติบโตของ Workflow
+- ทุก Agent ใหม่ควรใช้ Agent Template เพื่อคงมาตรฐานเดียวกัน
+- หากต้องการ Prompt, Diagram หรือ Template เพิ่มเติม สามารถสร้าง/ร้องขอได้จาก Prompt Pack ส่วนกลาง

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
   - "สถาปัตยกรรม": ARCHITECTURE.md  
   - "วงจรการทำงาน Agent": AGENT_LIFECYCLE.md
   - "Prompt Templates": PROMPTS_OVERVIEW.md
+  - "Workflow Chain": DHAMMA_WORKFLOW.md
   - "แผนงาน (Roadmap)": ROADMAP.md
   - "แก้ไขปัญหา": TROUBLESHOOTING.md
 


### PR DESCRIPTION
## Summary
- add a dedicated documentation page that details the end-to-end DhammaDD automation workflow and optional agents
- register the new workflow overview page in the MkDocs navigation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8c83978ac8320a0dbf99d5da2522a