### PR TITLE
Share build_actions via PrintPublishAdapter, document registry ordering, and add tests

### DIFF
--- a/src/automation_core/dispatch/adapters/base.py
+++ b/src/automation_core/dispatch/adapters/base.py
@@ -22,8 +22,8 @@ class DispatchAdapter(Protocol):
         """สร้างรายการ actions ตามสัญญาเดียวกันทุก adapter.
 
         ต้องคืน list ของ dict โดยมีโครงสร้างตามนี้:
-        - action print short/long: {"type": "print", "label": ..., "bytes": int}
-        - action publish: {"type": "noop", "label": "publish", "reason": str}
+        - action print short/long: {"type": "print", "label": ..., "bytes": int, "adapter": str, "target": str}
+        - action publish: {"type": "noop", "label": "publish", "reason": str, "adapter": str, "target": str}
 
         ค่า bytes ที่ติดลบต้องถูก clamp เป็น 0.
         """

--- a/src/automation_core/dispatch/adapters/base.py
+++ b/src/automation_core/dispatch/adapters/base.py
@@ -8,7 +8,8 @@ class DispatchAdapter(Protocol):
 
     name: str
 
-    def supports(self, target: str, platform: str) -> bool: ...
+    def supports(self, target: str, platform: str) -> bool:
+        """คืน True เมื่อ adapter รองรับ (target, platform) ที่ระบุ."""
 
     def build_actions(
         self,
@@ -17,4 +18,52 @@ class DispatchAdapter(Protocol):
         long_bytes: int,
         publish_reason: str,
         target: str,
-    ) -> list[dict[str, Any]]: ...
+    ) -> list[dict[str, Any]]:
+        """สร้างรายการ actions ตามสัญญาเดียวกันทุก adapter.
+
+        ต้องคืน list ของ dict โดยมีโครงสร้างตามนี้:
+        - action print short/long: {"type": "print", "label": ..., "bytes": int}
+        - action publish: {"type": "noop", "label": "publish", "reason": str}
+
+        ค่า bytes ที่ติดลบต้องถูก clamp เป็น 0.
+        """
+
+
+class PrintPublishAdapter:
+    """ฐานร่วมสำหรับ adapter ที่ต้องการ actions แบบ print + publish."""
+
+    name: str
+
+    def build_actions(
+        self,
+        *,
+        short_bytes: int,
+        long_bytes: int,
+        publish_reason: str,
+        target: str,
+    ) -> list[dict[str, Any]]:
+        short_b = max(0, short_bytes)
+        long_b = max(0, long_bytes)
+        return [
+            {
+                "type": "print",
+                "label": "short",
+                "bytes": short_b,
+                "adapter": self.name,
+                "target": target,
+            },
+            {
+                "type": "print",
+                "label": "long",
+                "bytes": long_b,
+                "adapter": self.name,
+                "target": target,
+            },
+            {
+                "type": "noop",
+                "label": "publish",
+                "reason": publish_reason,
+                "adapter": self.name,
+                "target": target,
+            },
+        ]

--- a/src/automation_core/dispatch/adapters/registry.py
+++ b/src/automation_core/dispatch/adapters/registry.py
@@ -21,6 +21,8 @@ _ADAPTERS: tuple[DispatchAdapter, ...] = (
 def get_adapter(target: str, platform: str) -> DispatchAdapter:
     """คืน adapter แบบ deterministic จาก (target, platform)
 
+    ตรวจสอบ adapter ตามลำดับใน _ADAPTERS และคืนตัวแรกที่รองรับ.
+
     Raises:
         DispatchAdapterError: code='unknown_target' เมื่อไม่พบ adapter ที่รองรับ
     """

--- a/src/automation_core/dispatch/adapters/youtube.py
+++ b/src/automation_core/dispatch/adapters/youtube.py
@@ -1,44 +1,10 @@
 from __future__ import annotations
 
-from typing import Any
+from .base import PrintPublishAdapter
 
 
-class YoutubeAdapter:
+class YoutubeAdapter(PrintPublishAdapter):
     name = "youtube"
 
     def supports(self, target: str, platform: str) -> bool:
         return target == "youtube" and platform == "youtube"
-
-    def build_actions(
-        self,
-        *,
-        short_bytes: int,
-        long_bytes: int,
-        publish_reason: str,
-        target: str,
-    ) -> list[dict[str, Any]]:
-        short_b = max(0, short_bytes)
-        long_b = max(0, long_bytes)
-        return [
-            {
-                "type": "print",
-                "label": "short",
-                "bytes": short_b,
-                "adapter": self.name,
-                "target": target,
-            },
-            {
-                "type": "print",
-                "label": "long",
-                "bytes": long_b,
-                "adapter": self.name,
-                "target": target,
-            },
-            {
-                "type": "noop",
-                "label": "publish",
-                "reason": publish_reason,
-                "adapter": self.name,
-                "target": target,
-            },
-        ]

--- a/src/automation_core/dispatch/adapters/youtube_community.py
+++ b/src/automation_core/dispatch/adapters/youtube_community.py
@@ -1,44 +1,10 @@
 from __future__ import annotations
 
-from typing import Any
+from .base import PrintPublishAdapter
 
 
-class YoutubeCommunityAdapter:
+class YoutubeCommunityAdapter(PrintPublishAdapter):
     name = "youtube_community"
 
     def supports(self, target: str, platform: str) -> bool:
         return target == "youtube_community" and platform == "youtube_community"
-
-    def build_actions(
-        self,
-        *,
-        short_bytes: int,
-        long_bytes: int,
-        publish_reason: str,
-        target: str,
-    ) -> list[dict[str, Any]]:
-        short_b = max(0, short_bytes)
-        long_b = max(0, long_bytes)
-        return [
-            {
-                "type": "print",
-                "label": "short",
-                "bytes": short_b,
-                "adapter": self.name,
-                "target": target,
-            },
-            {
-                "type": "print",
-                "label": "long",
-                "bytes": long_b,
-                "adapter": self.name,
-                "target": target,
-            },
-            {
-                "type": "noop",
-                "label": "publish",
-                "reason": publish_reason,
-                "adapter": self.name,
-                "target": target,
-            },
-        ]

--- a/tests/test_dispatch_adapters.py
+++ b/tests/test_dispatch_adapters.py
@@ -64,5 +64,6 @@ def test_youtube_adapter_build_actions_contract():
     assert actions[1]["bytes"] == 7
     assert actions[2]["reason"] == "dry_run default"
 
-    assert actions[0]["adapter"] == "youtube"
-    assert actions[0]["target"] == "youtube"
+    for action in actions:
+        assert action["adapter"] == "youtube"
+        assert action["target"] == "youtube"

--- a/tests/test_dispatch_adapters.py
+++ b/tests/test_dispatch_adapters.py
@@ -3,12 +3,18 @@ from __future__ import annotations
 import pytest
 
 from automation_core.dispatch.adapters.registry import DispatchAdapterError, get_adapter
+from automation_core.dispatch.adapters.youtube import YoutubeAdapter
 from automation_core.dispatch.adapters.youtube_community import YoutubeCommunityAdapter
 
 
 def test_registry_resolves_youtube_community():
     adapter = get_adapter("youtube_community", "youtube_community")
     assert adapter.name == "youtube_community"
+
+
+def test_registry_resolves_youtube():
+    adapter = get_adapter("youtube", "youtube")
+    assert adapter.name == "youtube"
 
 
 def test_registry_unknown_target_raises_deterministic_error():
@@ -38,3 +44,25 @@ def test_youtube_community_adapter_build_actions_contract():
 
     assert actions[0]["adapter"] == "youtube_community"
     assert actions[0]["target"] == "youtube_community"
+
+
+def test_youtube_adapter_build_actions_contract():
+    adapter = YoutubeAdapter()
+    actions = adapter.build_actions(
+        short_bytes=5,
+        long_bytes=7,
+        publish_reason="dry_run default",
+        target="youtube",
+    )
+
+    assert len(actions) == 3
+    assert actions[0]["type"] == "print" and actions[0]["label"] == "short"
+    assert actions[1]["type"] == "print" and actions[1]["label"] == "long"
+    assert actions[2]["type"] == "noop" and actions[2]["label"] == "publish"
+
+    assert actions[0]["bytes"] == 5
+    assert actions[1]["bytes"] == 7
+    assert actions[2]["reason"] == "dry_run default"
+
+    assert actions[0]["adapter"] == "youtube"
+    assert actions[0]["target"] == "youtube"


### PR DESCRIPTION
### Motivation
- Remove duplicated `build_actions` implementations in YouTube adapters to follow the DRY principle and simplify maintenance.
- Clarify the adapter contract so implementations and consumers have a clear, consistent action schema.
- Make registry behavior explicit so adapter precedence (first-match wins) is documented.
- Add missing tests to ensure both `youtube` and `youtube_community` adapters and registry resolution are covered.

### Description
- Introduced a shared base `PrintPublishAdapter` with `build_actions` in `src/automation_core/dispatch/adapters/base.py` and added docstrings to the `DispatchAdapter` protocol.
- Refactored `YoutubeAdapter` and `YoutubeCommunityAdapter` to inherit from `PrintPublishAdapter` and removed duplicated `build_actions` code in `src/automation_core/dispatch/adapters/youtube.py` and `src/automation_core/dispatch/adapters/youtube_community.py`.
- Documented deterministic adapter ordering in the `get_adapter` docstring in `src/automation_core/dispatch/adapters/registry.py`.
- Extended `tests/test_dispatch_adapters.py` to add `test_registry_resolves_youtube` and `test_youtube_adapter_build_actions_contract` covering the `youtube` adapter and registry resolution.

### Testing
- Ran `pytest tests/test_dispatch_adapters.py` to exercise registry resolution and adapter action contracts.
- All tests in that file passed (`5 passed`).
- The new tests verify `get_adapter("youtube", "youtube")` resolves correctly and that `YoutubeAdapter` and `YoutubeCommunityAdapter` return the expected action structures.
- No other automated test suites were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a3cb34548832080c73bb86acd34c9)