### PR TITLE
Harden preview bundle validation and tests

### DIFF
--- a/docs/BASELINE.md
+++ b/docs/BASELINE.md
@@ -297,7 +297,9 @@
 
 **ตัวอย่างอ้างอิง:** `samples/reference/preview/preview_summary_v1_example.json`
 
-### 15. สัญญา Preview Bundle (ใหม่)
+### 15. สัญญา Preview Bundle
+
+_หมายเหตุเวอร์ชัน:_ เพิ่มสัญญา Preview Bundle ใน baseline ฉบับนี้ (โปรดอัปเดตหมายเลขเวอร์ชันรีลีสเมื่อ lock-in แล้ว)
 
 **สคีมาไฟล์ `output/<run_id>/artifacts/preview_bundle.json` (preview_bundle_v0) ถือว่า STABLE**
 

--- a/src/automation_core/preview_bundle_v0.py
+++ b/src/automation_core/preview_bundle_v0.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import traceback
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -100,8 +99,6 @@ def _extract_preview_components(
             actions = result["actions"]
     summary = preview_summary.get("summary")
     if isinstance(summary, dict):
-        if status is None and isinstance(summary.get("mode"), str):
-            status = summary["mode"]
         if actions is None and isinstance(summary.get("actions"), list):
             actions = summary["actions"]
     if status is None:
@@ -139,8 +136,8 @@ def build_preview_bundle(
             "target": inputs["target"],
             "idempotency_key": controls["idempotency_key"],
             "controls": {
-                "dry_run": controls["dry_run"],
-                "allow_publish": controls["allow_publish"],
+                "dry_run": DEFAULT_DRY_RUN,
+                "allow_publish": DEFAULT_ALLOW_PUBLISH,
             },
             "content": {
                 "short": request["content_short"],
@@ -165,7 +162,7 @@ def _validate_hex_key(value: str) -> None:
     if not isinstance(value, str) or not value.strip():
         raise ValueError("bundle.idempotency_key is required")
     if len(value) != IDEMPOTENCY_HEX_LEN or any(
-        ch not in HEX_CHARS for ch in value.lower()
+        ch not in HEX_CHARS for ch in value
     ):
         raise ValueError(
             f"bundle.idempotency_key must be {IDEMPOTENCY_HEX_LEN} hex chars"
@@ -274,9 +271,11 @@ def validate_preview_bundle(payload: dict[str, Any], run_id: str) -> dict[str, A
     controls = bundle.get("controls")
     if not isinstance(controls, dict):
         raise ValueError("bundle.controls must be an object")
-    if controls.get("dry_run") is not DEFAULT_DRY_RUN:
+    dry_run = controls.get("dry_run")
+    if not isinstance(dry_run, bool) or dry_run is not DEFAULT_DRY_RUN:
         raise ValueError("bundle.controls.dry_run must be true")
-    if controls.get("allow_publish") is not DEFAULT_ALLOW_PUBLISH:
+    allow_publish = controls.get("allow_publish")
+    if not isinstance(allow_publish, bool) or allow_publish is not DEFAULT_ALLOW_PUBLISH:
         raise ValueError("bundle.controls.allow_publish must be false")
 
     content = bundle.get("content")
@@ -345,7 +344,10 @@ def generate_preview_bundle(
 
     output_path = base_dir / "output" / run_id / "artifacts" / BUNDLE_NAME
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), "utf-8")
+    output_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
     output_rel = output_path.relative_to(base_dir).as_posix()
     print(f"Preview bundle v0: wrote {output_rel}")
     return payload, output_path
@@ -370,7 +372,6 @@ def cli_main(argv: list[str] | None = None, base_dir: Path | None = None) -> int
         ValueError,
         json.JSONDecodeError,
     ) as exc:  # pragma: no cover - CLI error handling
-        traceback.print_exc()
         print(f"Error: {exc}")
         return 1
     return 0

--- a/tests/test_preview_bundle_v0.py
+++ b/tests/test_preview_bundle_v0.py
@@ -230,6 +230,19 @@ def test_preview_bundle_validate_relative_paths(tmp_path: Path) -> None:
         preview_bundle_v0.validate_preview_bundle(payload, run_id)
 
 
+@pytest.fixture
+def validation_test_payload(
+    request: pytest.FixtureRequest, tmp_path: Path
+) -> tuple[dict[str, Any], str]:
+    run_id = f"run_{request.node.name}"
+    write_publish_request_v1(tmp_path, run_id)
+    write_preview_summary_v1(
+        tmp_path, run_id, target="youtube_community", platform="youtube"
+    )
+    payload, _ = preview_bundle_v0.generate_preview_bundle(run_id, base_dir=tmp_path)
+    return payload, run_id
+
+
 def test_extract_preview_components_prefers_result_over_summary() -> None:
     summary_actions = [
         {"type": "print", "label": "short", "bytes": 1, "preview": "a"},
@@ -272,13 +285,10 @@ def test_extract_preview_components_falls_back_without_result() -> None:
     assert errors == []
 
 
-def test_preview_bundle_rejects_uppercase_idempotency_key(tmp_path: Path) -> None:
-    run_id = "run_preview_bundle_uppercase_key"
-    write_publish_request_v1(tmp_path, run_id)
-    write_preview_summary_v1(
-        tmp_path, run_id, target="youtube_community", platform="youtube"
-    )
-    payload, _ = preview_bundle_v0.generate_preview_bundle(run_id, base_dir=tmp_path)
+def test_preview_bundle_rejects_uppercase_idempotency_key(
+    validation_test_payload: tuple[dict[str, Any], str],
+) -> None:
+    payload, run_id = validation_test_payload
 
     payload["bundle"]["idempotency_key"] = payload["bundle"]["idempotency_key"].upper()
 
@@ -286,13 +296,10 @@ def test_preview_bundle_rejects_uppercase_idempotency_key(tmp_path: Path) -> Non
         preview_bundle_v0.validate_preview_bundle(payload, run_id)
 
 
-def test_preview_bundle_rejects_invalid_action_order(tmp_path: Path) -> None:
-    run_id = "run_preview_bundle_bad_action_order"
-    write_publish_request_v1(tmp_path, run_id)
-    write_preview_summary_v1(
-        tmp_path, run_id, target="youtube_community", platform="youtube"
-    )
-    payload, _ = preview_bundle_v0.generate_preview_bundle(run_id, base_dir=tmp_path)
+def test_preview_bundle_rejects_invalid_action_order(
+    validation_test_payload: tuple[dict[str, Any], str],
+) -> None:
+    payload, run_id = validation_test_payload
     actions = payload["bundle"]["preview"]["actions"]
     actions[0], actions[1] = actions[1], actions[0]
 
@@ -303,26 +310,20 @@ def test_preview_bundle_rejects_invalid_action_order(tmp_path: Path) -> None:
         preview_bundle_v0.validate_preview_bundle(payload, run_id)
 
 
-def test_preview_bundle_rejects_invalid_publish_reason(tmp_path: Path) -> None:
-    run_id = "run_preview_bundle_bad_publish_reason"
-    write_publish_request_v1(tmp_path, run_id)
-    write_preview_summary_v1(
-        tmp_path, run_id, target="youtube_community", platform="youtube"
-    )
-    payload, _ = preview_bundle_v0.generate_preview_bundle(run_id, base_dir=tmp_path)
+def test_preview_bundle_rejects_invalid_publish_reason(
+    validation_test_payload: tuple[dict[str, Any], str],
+) -> None:
+    payload, run_id = validation_test_payload
     payload["bundle"]["preview"]["actions"][2]["reason"] = "publish"
 
     with pytest.raises(ValueError, match="bundle.preview.actions publish reason"):
         preview_bundle_v0.validate_preview_bundle(payload, run_id)
 
 
-def test_preview_bundle_rejects_invalid_error_step(tmp_path: Path) -> None:
-    run_id = "run_preview_bundle_bad_error_step"
-    write_publish_request_v1(tmp_path, run_id)
-    write_preview_summary_v1(
-        tmp_path, run_id, target="youtube_community", platform="youtube"
-    )
-    payload, _ = preview_bundle_v0.generate_preview_bundle(run_id, base_dir=tmp_path)
+def test_preview_bundle_rejects_invalid_error_step(
+    validation_test_payload: tuple[dict[str, Any], str],
+) -> None:
+    payload, run_id = validation_test_payload
     payload["bundle"]["preview"]["errors"] = [
         {
             "code": "preview_error",

--- a/tests/test_preview_bundle_v0.py
+++ b/tests/test_preview_bundle_v0.py
@@ -70,6 +70,7 @@ def write_preview_summary_v1(
     short: str = "preview short",
     long: str = "preview long",
     errors: list[dict[str, Any]] | None = None,
+    include_result: bool = False,
     status: str = "ok",
 ) -> dict[str, Any]:
     actions = [
@@ -102,11 +103,12 @@ def write_preview_summary_v1(
         },
         "policy": {"status": "preview_only", "reasons": []},
         "errors": errors or [],
-        "result": {
+    }
+    if include_result:
+        payload["result"] = {
             "status": status,
             "actions": actions,
-        },
-    }
+        }
     path = base_dir / "output" / run_id / "artifacts" / "preview_summary.json"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
@@ -127,7 +129,6 @@ def test_preview_bundle_happy_path_writes_file(tmp_path: Path) -> None:
         platform="youtube",
         short="short sample",
         long="long sample preview",
-        status="ok",
     )
 
     checked_at = TEST_CHECKED_AT
@@ -226,4 +227,110 @@ def test_preview_bundle_validate_relative_paths(tmp_path: Path) -> None:
     )
 
     with pytest.raises(ValueError, match="inputs.publish_request"):
+        preview_bundle_v0.validate_preview_bundle(payload, run_id)
+
+
+def test_extract_preview_components_prefers_result_over_summary() -> None:
+    summary_actions = [
+        {"type": "print", "label": "short", "bytes": 1, "preview": "a"},
+        {"type": "print", "label": "long", "bytes": 2, "preview": "bb"},
+        {"type": "noop", "label": "publish", "reason": "no_publish_in_v0"},
+    ]
+    result_actions = [
+        {"type": "print", "label": "short", "bytes": 3, "preview": "ccc"},
+        {"type": "print", "label": "long", "bytes": 4, "preview": "dddd"},
+        {"type": "noop", "label": "publish", "reason": "no_publish_in_v0"},
+    ]
+    status, actions, errors = preview_bundle_v0._extract_preview_components(
+        {
+            "summary": {"actions": summary_actions},
+            "result": {"status": "ok", "actions": result_actions},
+            "errors": [],
+        }
+    )
+
+    assert status == "ok"
+    assert actions == result_actions
+    assert errors == []
+
+
+def test_extract_preview_components_falls_back_without_result() -> None:
+    summary_actions = [
+        {"type": "print", "label": "short", "bytes": 1, "preview": "a"},
+        {"type": "print", "label": "long", "bytes": 2, "preview": "bb"},
+        {"type": "noop", "label": "publish", "reason": "no_publish_in_v0"},
+    ]
+    status, actions, errors = preview_bundle_v0._extract_preview_components(
+        {
+            "summary": {"actions": summary_actions},
+            "errors": [],
+        }
+    )
+
+    assert status == "ok"
+    assert actions == summary_actions
+    assert errors == []
+
+
+def test_preview_bundle_rejects_uppercase_idempotency_key(tmp_path: Path) -> None:
+    run_id = "run_preview_bundle_uppercase_key"
+    write_publish_request_v1(tmp_path, run_id)
+    write_preview_summary_v1(
+        tmp_path, run_id, target="youtube_community", platform="youtube"
+    )
+    payload, _ = preview_bundle_v0.generate_preview_bundle(run_id, base_dir=tmp_path)
+
+    payload["bundle"]["idempotency_key"] = payload["bundle"]["idempotency_key"].upper()
+
+    with pytest.raises(ValueError, match="bundle.idempotency_key"):
+        preview_bundle_v0.validate_preview_bundle(payload, run_id)
+
+
+def test_preview_bundle_rejects_invalid_action_order(tmp_path: Path) -> None:
+    run_id = "run_preview_bundle_bad_action_order"
+    write_publish_request_v1(tmp_path, run_id)
+    write_preview_summary_v1(
+        tmp_path, run_id, target="youtube_community", platform="youtube"
+    )
+    payload, _ = preview_bundle_v0.generate_preview_bundle(run_id, base_dir=tmp_path)
+    actions = payload["bundle"]["preview"]["actions"]
+    actions[0], actions[1] = actions[1], actions[0]
+
+    with pytest.raises(
+        ValueError,
+        match="bundle.preview.actions short must be print/short",
+    ):
+        preview_bundle_v0.validate_preview_bundle(payload, run_id)
+
+
+def test_preview_bundle_rejects_invalid_publish_reason(tmp_path: Path) -> None:
+    run_id = "run_preview_bundle_bad_publish_reason"
+    write_publish_request_v1(tmp_path, run_id)
+    write_preview_summary_v1(
+        tmp_path, run_id, target="youtube_community", platform="youtube"
+    )
+    payload, _ = preview_bundle_v0.generate_preview_bundle(run_id, base_dir=tmp_path)
+    payload["bundle"]["preview"]["actions"][2]["reason"] = "publish"
+
+    with pytest.raises(ValueError, match="bundle.preview.actions publish reason"):
+        preview_bundle_v0.validate_preview_bundle(payload, run_id)
+
+
+def test_preview_bundle_rejects_invalid_error_step(tmp_path: Path) -> None:
+    run_id = "run_preview_bundle_bad_error_step"
+    write_publish_request_v1(tmp_path, run_id)
+    write_preview_summary_v1(
+        tmp_path, run_id, target="youtube_community", platform="youtube"
+    )
+    payload, _ = preview_bundle_v0.generate_preview_bundle(run_id, base_dir=tmp_path)
+    payload["bundle"]["preview"]["errors"] = [
+        {
+            "code": "preview_error",
+            "message": "failed",
+            "step": "adapter.publish",
+            "detail": {},
+        }
+    ]
+
+    with pytest.raises(ValueError, match="error.step must be 'adapter.preview'"):
         preview_bundle_v0.validate_preview_bundle(payload, run_id)


### PR DESCRIPTION
### Motivation
- Close validation gaps in the preview bundle contract to ensure generated artifacts strictly follow the baseline expectations.
- Make `idempotency_key` and `controls` handling deterministic and explicit to avoid subtle acceptance of invalid inputs.
- Add unit tests that exercise previously-uncovered fallback and error-path behavior to prevent regressions.

### Description
- Tighten preview extraction in `src/automation_core/preview_bundle_v0.py` by updating `_extract_preview_components` to avoid using `summary.mode` as a fallback for `status` when a `result` is present and to prefer `result` values when available.
- Enforce contract defaults when building bundles by setting `bundle.controls` to `DEFAULT_DRY_RUN` and `DEFAULT_ALLOW_PUBLISH`, and strengthen validation to require boolean types for these fields in `validate_preview_bundle`.
- Harden idempotency validation by checking raw characters in `_validate_hex_key` (disallowing uppercase hex) and update file writing to use `encoding="utf-8"`, plus remove noisy `traceback.print_exc()` from CLI error handling.
- Update tests in `tests/test_preview_bundle_v0.py` to add coverage for result-vs-summary extraction, uppercase idempotency rejection, invalid action order, publish reason, and error step, and make `write_preview_summary_v1` optionally include a `result` field.

### Testing
- Ran `pytest tests/test_preview_bundle_v0.py` which executed the full test file added/updated for this change.
- All tests passed: `12 passed` (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c31ec88608320bea084200dadd2fa)