### PR TITLE
Improve preview bundle status fallback and CLI error handling; expand tests

### DIFF
--- a/src/automation_core/preview_bundle_v0.py
+++ b/src/automation_core/preview_bundle_v0.py
@@ -99,10 +99,14 @@ def _extract_preview_components(
             actions = result["actions"]
     summary = preview_summary.get("summary")
     if isinstance(summary, dict):
+        if status is None and isinstance(summary.get("mode"), str):
+            status = summary["mode"]
         if actions is None and isinstance(summary.get("actions"), list):
             actions = summary["actions"]
     if status is None:
         status = "error" if errors else "ok"
+    elif errors:
+        status = "error"
     if actions is None:
         actions = []
     return status, _copy_dict_list(actions), _copy_dict_list(errors)
@@ -367,11 +371,7 @@ def cli_main(argv: list[str] | None = None, base_dir: Path | None = None) -> int
     try:
         if args.command == "bundle":
             generate_preview_bundle(args.run_id, base_dir=base_dir)
-    except (
-        FileNotFoundError,
-        ValueError,
-        json.JSONDecodeError,
-    ) as exc:  # pragma: no cover - CLI error handling
+    except Exception as exc:  # pragma: no cover - surfaces CLI errors
         print(f"Error: {exc}")
         return 1
     return 0

--- a/src/automation_core/preview_bundle_v0.py
+++ b/src/automation_core/preview_bundle_v0.py
@@ -103,10 +103,10 @@ def _extract_preview_components(
             status = summary["mode"]
         if actions is None and isinstance(summary.get("actions"), list):
             actions = summary["actions"]
-    if status is None:
-        status = "error" if errors else "ok"
-    elif errors:
+    if errors:
         status = "error"
+    elif status is None:
+        status = "ok"
     if actions is None:
         actions = []
     return status, _copy_dict_list(actions), _copy_dict_list(errors)

--- a/tests/test_preview_bundle_v0.py
+++ b/tests/test_preview_bundle_v0.py
@@ -138,15 +138,17 @@ def test_preview_bundle_happy_path_writes_file(tmp_path: Path) -> None:
 
     assert output_path is not None
     assert output_path.is_file()
-    saved = json.loads(output_path.read_text(encoding="utf-8"))
+    output_text = output_path.read_text(encoding="utf-8")
+    saved = json.loads(output_text)
     assert saved == payload
+    assert output_text == json.dumps(payload, ensure_ascii=False, indent=2)
     assert payload["schema_version"] == "v1"
     assert payload["engine"] == "preview_bundle_v0"
     assert payload["run_id"] == run_id
     assert payload["bundle"]["platform"] == publish_request["inputs"]["platform"]
     assert payload["bundle"]["target"] == publish_request["inputs"]["target"]
     assert payload["bundle"]["controls"] == {"dry_run": True, "allow_publish": False}
-    assert payload["bundle"]["preview"]["status"] == "ok"
+    assert payload["bundle"]["preview"]["status"] == "dry_run"
     assert (
         payload["bundle"]["preview"]["actions"] == preview_summary["summary"]["actions"]
     )
@@ -275,14 +277,45 @@ def test_extract_preview_components_falls_back_without_result() -> None:
     ]
     status, actions, errors = preview_bundle_v0._extract_preview_components(
         {
-            "summary": {"actions": summary_actions},
+            "summary": {"mode": "dry_run", "actions": summary_actions},
+            "errors": [],
+        }
+    )
+
+    assert status == "dry_run"
+    assert actions == summary_actions
+    assert errors == []
+
+
+def test_extract_preview_components_falls_back_without_summary() -> None:
+    result_actions = [
+        {"type": "print", "label": "short", "bytes": 3, "preview": "ccc"},
+        {"type": "print", "label": "long", "bytes": 4, "preview": "dddd"},
+        {"type": "noop", "label": "publish", "reason": "no_publish_in_v0"},
+    ]
+    status, actions, errors = preview_bundle_v0._extract_preview_components(
+        {
+            "result": {"status": "ok", "actions": result_actions},
             "errors": [],
         }
     )
 
     assert status == "ok"
-    assert actions == summary_actions
+    assert actions == result_actions
     assert errors == []
+
+
+def test_extract_preview_components_marks_error_when_errors_present() -> None:
+    status, actions, errors = preview_bundle_v0._extract_preview_components(
+        {
+            "summary": {"mode": "dry_run", "actions": []},
+            "errors": [{"code": "preview_error"}],
+        }
+    )
+
+    assert status == "error"
+    assert actions == []
+    assert errors == [{"code": "preview_error"}]
 
 
 def test_preview_bundle_rejects_uppercase_idempotency_key(


### PR DESCRIPTION
### Motivation
- Ensure preview bundle status is derived from `summary.mode` when `result.status` is absent to surface the adapter-provided mode.
- Make preview errors always cause an `error` status even when a `mode` is present so failures aren't masked.
- Align CLI behavior with other modules by surfacing all exceptions from `cli_main`.
- Add tests to cover fallback paths and JSON output formatting to prevent regressions.

### Description
- Updated `preview_bundle_v0._extract_preview_components` to use `summary.mode` when `result.status` is not provided and to force `status = "error"` when `errors` are present.
- Broadened `cli_main` exception handling in `preview_bundle_v0` to `except Exception` for consistent CLI error reporting.
- Extended tests in `tests/test_preview_bundle_v0.py` to assert the written JSON equals `json.dumps(payload, ensure_ascii=False, indent=2)` and added new tests for: fallback from `result`->`summary`, fallback when `summary` is missing, and that errors force an `error` status.

### Testing
- Ran `pytest tests/test_preview_bundle_v0.py`, which executed 14 tests and all passed (14 passed in ~0.77s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c373435cc8320823cdf68731f8af2)